### PR TITLE
BUG: Update failing example tests

### DIFF
--- a/ConvertMorphologikaLandmarks/ConvertMorphologikaLandmarks.py
+++ b/ConvertMorphologikaLandmarks/ConvertMorphologikaLandmarks.py
@@ -274,24 +274,16 @@ class ConvertMorphologikaLandmarksTest(ScriptedLoadableModuleTest):
     module.  For example, if a developer removes a feature that you depend on,
     your test should break so they know that the feature is needed.
     """
-
     self.delayDisplay("Starting the test")
     #
     # first, get some data
     #
-    import urllib
-    downloads = (
-        ('http://slicer.kitware.com/midas3/download?items=5767', 'FA.nrrd', slicer.util.loadVolume),
-        )
-
-    for url,name,loader in downloads:
-      filePath = slicer.app.temporaryPath + '/' + name
-      if not os.path.exists(filePath) or os.stat(filePath).st_size == 0:
-        logging.info('Requesting download %s from %s...\n' % (name, url))
-        urllib.urlretrieve(url, filePath)
-      if loader:
-        logging.info('Loading %s...' % (name,))
-        loader(filePath)
+    import SampleData
+    SampleData.downloadFromURL(
+      nodeNames='FA',
+      fileNames='FA.nrrd',
+      uris='http://slicer.kitware.com/midas3/download?items=5767',
+      checksums='SHA256:12d17fba4f2e1f1a843f0757366f28c3f3e1a8bb38836f0de2a32bb1cd476560')
     self.delayDisplay('Finished with download and loading')
 
     volumeNode = slicer.util.getNode(pattern="FA")

--- a/GPA/GPA.py
+++ b/GPA/GPA.py
@@ -1819,24 +1819,16 @@ class GPATest(ScriptedLoadableModuleTest):
     module.  For example, if a developer removes a feature that you depend on,
     your test should break so they know that the feature is needed.
     """
-
     self.delayDisplay("Starting the test")
     #
     # first, get some data
     #
-    import urllib
-    downloads = (
-        ('http://slicer.kitware.com/midas3/download?items=5767', 'FA.nrrd', slicer.util.loadVolume),
-        )
-
-    for url,name,loader in downloads:
-      filePath = slicer.app.temporaryPath + '/' + name
-      if not os.path.exists(filePath) or os.stat(filePath).st_size == 0:
-        logging.info('Requesting download %s from %s...\n' % (name, url))
-        urllib.urlretrieve(url, filePath)
-      if loader:
-        logging.info('Loading %s...' % (name,))
-        loader(filePath)
+    import SampleData
+    SampleData.downloadFromURL(
+      nodeNames='FA',
+      fileNames='FA.nrrd',
+      uris='http://slicer.kitware.com/midas3/download?items=5767',
+      checksums='SHA256:12d17fba4f2e1f1a843f0757366f28c3f3e1a8bb38836f0de2a32bb1cd476560')
     self.delayDisplay('Finished with download and loading')
 
     volumeNode = slicer.util.getNode(pattern="FA")

--- a/ImportSurfaceToSegment/ImportSurfaceToSegment.py
+++ b/ImportSurfaceToSegment/ImportSurfaceToSegment.py
@@ -234,24 +234,16 @@ class ImportSurfaceToSegmentTest(ScriptedLoadableModuleTest):
     module.  For example, if a developer removes a feature that you depend on,
     your test should break so they know that the feature is needed.
     """
-
     self.delayDisplay("Starting the test")
     #
     # first, get some data
     #
-    import urllib
-    downloads = (
-        ('http://slicer.kitware.com/midas3/download?items=5767', 'FA.nrrd', slicer.util.loadVolume),
-        )
-
-    for url,name,loader in downloads:
-      filePath = slicer.app.temporaryPath + '/' + name
-      if not os.path.exists(filePath) or os.stat(filePath).st_size == 0:
-        logging.info('Requesting download %s from %s...\n' % (name, url))
-        urllib.urlretrieve(url, filePath)
-      if loader:
-        logging.info('Loading %s...' % (name,))
-        loader(filePath)
+    import SampleData
+    SampleData.downloadFromURL(
+      nodeNames='FA',
+      fileNames='FA.nrrd',
+      uris='http://slicer.kitware.com/midas3/download?items=5767',
+      checksums='SHA256:12d17fba4f2e1f1a843f0757366f28c3f3e1a8bb38836f0de2a32bb1cd476560')
     self.delayDisplay('Finished with download and loading')
 
     volumeNode = slicer.util.getNode(pattern="FA")

--- a/ReadLandmarkFile/ReadLandmarkFile.py
+++ b/ReadLandmarkFile/ReadLandmarkFile.py
@@ -257,24 +257,16 @@ class ReadLandmarkFileTest(ScriptedLoadableModuleTest):
     module.  For example, if a developer removes a feature that you depend on,
     your test should break so they know that the feature is needed.
     """
-
     self.delayDisplay("Starting the test")
     #
     # first, get some data
     #
-    import urllib
-    downloads = (
-        ('http://slicer.kitware.com/midas3/download?items=5767', 'FA.nrrd', slicer.util.loadVolume),
-        )
-
-    for url,name,loader in downloads:
-      filePath = slicer.app.temporaryPath + '/' + name
-      if not os.path.exists(filePath) or os.stat(filePath).st_size == 0:
-        logging.info('Requesting download %s from %s...\n' % (name, url))
-        urllib.urlretrieve(url, filePath)
-      if loader:
-        logging.info('Loading %s...' % (name,))
-        loader(filePath)
+    import SampleData
+    SampleData.downloadFromURL(
+      nodeNames='FA',
+      fileNames='FA.nrrd',
+      uris='http://slicer.kitware.com/midas3/download?items=5767',
+      checksums='SHA256:12d17fba4f2e1f1a843f0757366f28c3f3e1a8bb38836f0de2a32bb1cd476560')
     self.delayDisplay('Finished with download and loading')
 
     volumeNode = slicer.util.getNode(pattern="FA")

--- a/ResampleCurves/ResampleCurves.py
+++ b/ResampleCurves/ResampleCurves.py
@@ -300,6 +300,19 @@ class ResampleCurvesLogic(ScriptedLoadableModuleLogic):
 
     return True
 
+  def hasImageData(self, volumeNode):
+    """This is an example logic method that
+    returns true if the passed in volume
+    node has valid image data
+    """
+    if not volumeNode:
+      logging.debug('hasImageData failed: no volume node')
+      return False
+    if volumeNode.GetImageData() is None:
+      logging.debug('hasImageData failed: no image data in volume node')
+      return False
+    return True
+
 
 class ResampleCurvesTest(ScriptedLoadableModuleTest):
   """
@@ -330,24 +343,16 @@ class ResampleCurvesTest(ScriptedLoadableModuleTest):
     module.  For example, if a developer removes a feature that you depend on,
     your test should break so they know that the feature is needed.
     """
-
     self.delayDisplay("Starting the test")
     #
     # first, get some data
     #
-    import urllib
-    downloads = (
-        ('http://slicer.kitware.com/midas3/download?items=5767', 'FA.nrrd', slicer.util.loadVolume),
-        )
-
-    for url,name,loader in downloads:
-      filePath = slicer.app.temporaryPath + '/' + name
-      if not os.path.exists(filePath) or os.stat(filePath).st_size == 0:
-        logging.info('Requesting download %s from %s...\n' % (name, url))
-        urllib.urlretrieve(url, filePath)
-      if loader:
-        logging.info('Loading %s...' % (name,))
-        loader(filePath)
+    import SampleData
+    SampleData.downloadFromURL(
+      nodeNames='FA',
+      fileNames='FA.nrrd',
+      uris='http://slicer.kitware.com/midas3/download?items=5767',
+      checksums='SHA256:12d17fba4f2e1f1a843f0757366f28c3f3e1a8bb38836f0de2a32bb1cd476560')
     self.delayDisplay('Finished with download and loading')
 
     volumeNode = slicer.util.getNode(pattern="FA")

--- a/SemiLandmark/SemiLandmark.py
+++ b/SemiLandmark/SemiLandmark.py
@@ -586,29 +586,19 @@ class SemiLandmarkTest(ScriptedLoadableModuleTest):
       module.  For example, if a developer removes a feature that you depend on,
       your test should break so they know that the feature is needed.
       """
-    
     self.delayDisplay("Starting the test")
     #
     # first, get some data
     #
-    import urllib
-    downloads = (
-                 ('http://slicer.kitware.com/midas3/download?items=5767', 'FA.nrrd', slicer.util.loadVolume),
-                 )
-    for url,name,loader in downloads:
-      filePath = slicer.app.temporaryPath + '/' + name
-      if not os.path.exists(filePath) or os.stat(filePath).st_size == 0:
-        logging.info('Requesting download %s from %s...\n' % (name, url))
-        urllib.urlretrieve(url, filePath)
-      if loader:
-        logging.info('Loading %s...' % (name,))
-        loader(filePath)
+    import SampleData
+    SampleData.downloadFromURL(
+      nodeNames='FA',
+      fileNames='FA.nrrd',
+      uris='http://slicer.kitware.com/midas3/download?items=5767',
+      checksums='SHA256:12d17fba4f2e1f1a843f0757366f28c3f3e1a8bb38836f0de2a32bb1cd476560')
     self.delayDisplay('Finished with download and loading')
-    
+
     volumeNode = slicer.util.getNode(pattern="FA")
     logic = SemiLandmarkLogic()
     self.assertIsNotNone( logic.hasImageData(volumeNode) )
     self.delayDisplay('Test passed!')
-
-
-

--- a/SemiLandmark/Testing/SemiLandmarkBackup.py
+++ b/SemiLandmark/Testing/SemiLandmarkBackup.py
@@ -435,29 +435,19 @@ class SemiLandmarkTest(ScriptedLoadableModuleTest):
       module.  For example, if a developer removes a feature that you depend on,
       your test should break so they know that the feature is needed.
       """
-    
     self.delayDisplay("Starting the test")
     #
     # first, get some data
     #
-    import urllib
-    downloads = (
-                 ('http://slicer.kitware.com/midas3/download?items=5767', 'FA.nrrd', slicer.util.loadVolume),
-                 )
-    for url,name,loader in downloads:
-      filePath = slicer.app.temporaryPath + '/' + name
-      if not os.path.exists(filePath) or os.stat(filePath).st_size == 0:
-        logging.info('Requesting download %s from %s...\n' % (name, url))
-        urllib.urlretrieve(url, filePath)
-      if loader:
-        logging.info('Loading %s...' % (name,))
-        loader(filePath)
+    import SampleData
+    SampleData.downloadFromURL(
+      nodeNames='FA',
+      fileNames='FA.nrrd',
+      uris='http://slicer.kitware.com/midas3/download?items=5767',
+      checksums='SHA256:12d17fba4f2e1f1a843f0757366f28c3f3e1a8bb38836f0de2a32bb1cd476560')
     self.delayDisplay('Finished with download and loading')
-    
+
     volumeNode = slicer.util.getNode(pattern="FA")
     logic = SemiLandmarkLogic()
     self.assertIsNotNone( logic.hasImageData(volumeNode) )
     self.delayDisplay('Test passed!')
-
-
-

--- a/SkyscanReconImport/SkyscanReconImport.py
+++ b/SkyscanReconImport/SkyscanReconImport.py
@@ -361,24 +361,16 @@ class SkyscanReconImportTest(ScriptedLoadableModuleTest):
     module.  For example, if a developer removes a feature that you depend on,
     your test should break so they know that the feature is needed.
     """
-
     self.delayDisplay("Starting the test")
     #
     # first, get some data
     #
-    import urllib
-    downloads = (
-        ('http://slicer.kitware.com/midas3/download?items=5767', 'FA.nrrd', slicer.util.loadVolume),
-        )
-
-    for url,name,loader in downloads:
-      filePath = slicer.app.temporaryPath + '/' + name
-      if not os.path.exists(filePath) or os.stat(filePath).st_size == 0:
-        logging.info('Requesting download %s from %s...\n' % (name, url))
-        urllib.urlretrieve(url, filePath)
-      if loader:
-        logging.info('Loading %s...' % (name,))
-        loader(filePath)
+    import SampleData
+    SampleData.downloadFromURL(
+      nodeNames='FA',
+      fileNames='FA.nrrd',
+      uris='http://slicer.kitware.com/midas3/download?items=5767',
+      checksums='SHA256:12d17fba4f2e1f1a843f0757366f28c3f3e1a8bb38836f0de2a32bb1cd476560')
     self.delayDisplay('Finished with download and loading')
 
     volumeNode = slicer.util.getNode(pattern="FA")

--- a/TransferSemiLandmarks/TransferSemiLandmarks.py
+++ b/TransferSemiLandmarks/TransferSemiLandmarks.py
@@ -237,29 +237,19 @@ class TransferSemiLandmarksTest(ScriptedLoadableModuleTest):
       module.  For example, if a developer removes a feature that you depend on,
       your test should break so they know that the feature is needed.
       """
-    
     self.delayDisplay("Starting the test")
     #
     # first, get some data
     #
-    import urllib
-    downloads = (
-                 ('http://slicer.kitware.com/midas3/download?items=5767', 'FA.nrrd', slicer.util.loadVolume),
-                 )
-    for url,name,loader in downloads:
-      filePath = slicer.app.temporaryPath + '/' + name
-      if not os.path.exists(filePath) or os.stat(filePath).st_size == 0:
-        logging.info('Requesting download %s from %s...\n' % (name, url))
-        urllib.urlretrieve(url, filePath)
-      if loader:
-        logging.info('Loading %s...' % (name,))
-        loader(filePath)
+    import SampleData
+    SampleData.downloadFromURL(
+      nodeNames='FA',
+      fileNames='FA.nrrd',
+      uris='http://slicer.kitware.com/midas3/download?items=5767',
+      checksums='SHA256:12d17fba4f2e1f1a843f0757366f28c3f3e1a8bb38836f0de2a32bb1cd476560')
     self.delayDisplay('Finished with download and loading')
-    
+
     volumeNode = slicer.util.getNode(pattern="FA")
     logic = TransferSemiLandmarksLogic()
     self.assertIsNotNone( logic.hasImageData(volumeNode) )
     self.delayDisplay('Test passed!')
-
-
-

--- a/VolumeToMesh/VolumeToMesh.py
+++ b/VolumeToMesh/VolumeToMesh.py
@@ -245,29 +245,19 @@ class VolumeToMeshTest(ScriptedLoadableModuleTest):
       module.  For example, if a developer removes a feature that you depend on,
       your test should break so they know that the feature is needed.
       """
-    
     self.delayDisplay("Starting the test")
     #
     # first, get some data
     #
-    import urllib
-    downloads = (
-                 ('http://slicer.kitware.com/midas3/download?items=5767', 'FA.nrrd', slicer.util.loadVolume),
-                 )
-    for url,name,loader in downloads:
-      filePath = slicer.app.temporaryPath + '/' + name
-      if not os.path.exists(filePath) or os.stat(filePath).st_size == 0:
-        logging.info('Requesting download %s from %s...\n' % (name, url))
-        urllib.urlretrieve(url, filePath)
-      if loader:
-        logging.info('Loading %s...' % (name,))
-        loader(filePath)
+    import SampleData
+    SampleData.downloadFromURL(
+      nodeNames='FA',
+      fileNames='FA.nrrd',
+      uris='http://slicer.kitware.com/midas3/download?items=5767',
+      checksums='SHA256:12d17fba4f2e1f1a843f0757366f28c3f3e1a8bb38836f0de2a32bb1cd476560')
     self.delayDisplay('Finished with download and loading')
-    
+
     volumeNode = slicer.util.getNode(pattern="FA")
     logic = VolumeToMeshLogic()
     self.assertIsNotNone( logic.hasImageData(volumeNode) )
     self.delayDisplay('Test passed!')
-
-
-


### PR DESCRIPTION
This fixes some example tests that are in the code that are failing due to incompatibilities with python 3. This includes there not being a `urllib.urlretrieve` in python3.  I've updated all the example test cases with the latest from the [template](https://github.com/Slicer/Slicer/blob/aedb7d6702a30b485be952f2c933dfd96f072f02/Utilities/Templates/Modules/ScriptedDesigner/TemplateKey.py). These updates will only work on Slicer 4.11 which appears to be ok as SlicerMorph is not distributed for Slicer 4.10 stable.

This fixes a currently [failing test](http://slicer.cdash.org/testDetails.php?test=9860570&build=1784983).