### PR TITLE
STYLE: Trim trailing whitespace

### DIFF
--- a/ConvertMorphologikaLandmarks/ConvertMorphologikaLandmarks.py
+++ b/ConvertMorphologikaLandmarks/ConvertMorphologikaLandmarks.py
@@ -20,13 +20,13 @@ class ConvertMorphologikaLandmarks(ScriptedLoadableModule):
     self.parent.dependencies = []
     self.parent.contributors = ["Sara Rolfe (UW), Murat Maga (UW)"] # replace with "Firstname Lastname (Organization)"
     self.parent.helpText = """
-This module imports a file containing landmarks in Morphologika format and saves them to a file in Slicer FCSV format, one file per subject. 
+This module imports a file containing landmarks in Morphologika format and saves them to a file in Slicer FCSV format, one file per subject.
 """
     self.parent.helpText += self.getDefaultModuleDocumentationLink()
     self.parent.acknowledgementText = """
-This module was developed by Sara Rolfe and Murat Maga, through a NSF ABI Development grant, "An Integrated Platform for Retrieval, Visualization and Analysis of 
+This module was developed by Sara Rolfe and Murat Maga, through a NSF ABI Development grant, "An Integrated Platform for Retrieval, Visualization and Analysis of
 3D Morphology From Digital Biological Collections" (Award Numbers: 1759883 (Murat Maga), 1759637 (Adam Summers), 1759839 (Douglas Boyer)).
-https://nsf.gov/awardsearch/showAward?AWD_ID=1759883&HistoricalAwards=false 
+https://nsf.gov/awardsearch/showAward?AWD_ID=1759883&HistoricalAwards=false
 """ # replace with organization, grant and thanks.
 
 #
@@ -59,7 +59,7 @@ class ConvertMorphologikaLandmarksWidget(ScriptedLoadableModuleWidget):
     self.inputFileSelector = ctk.ctkPathLineEdit()
     self.inputFileSelector.setToolTip( "Select Morphologika landmark file for conversion" )
     parametersFormLayout.addRow("Select file containing landmark names and coordinates to load:", self.inputFileSelector)
-    
+
     #
     # output directory selector
     #
@@ -86,7 +86,7 @@ class ConvertMorphologikaLandmarksWidget(ScriptedLoadableModuleWidget):
     # connections
     self.applyButton.connect('clicked(bool)', self.onApplyButton)
     self.inputFileSelector.connect('validInputChanged(bool)', self.onSelectInput)
- 
+
     # Add vertical spacer
     self.layout.addStretch(1)
 
@@ -98,7 +98,7 @@ class ConvertMorphologikaLandmarksWidget(ScriptedLoadableModuleWidget):
     pass
 
   def onSelectInput(self):
-    self.applyButton.enabled = bool(self.inputFileSelector.currentPath) 
+    self.applyButton.enabled = bool(self.inputFileSelector.currentPath)
 
 
   def onApplyButton(self):
@@ -197,10 +197,10 @@ class ConvertMorphologikaLandmarksLogic(ScriptedLoadableModuleLogic):
     nameIndex=0
     rawIndex=0
 
-    #Scan file for data size 
+    #Scan file for data size
     for num, line in enumerate(data, 0):
       if 'individuals' in line.lower():
-        subjectNumber= int(data[num+1])	
+        subjectNumber= int(data[num+1])
       elif 'landmarks' in line.lower():
         landmarkNumber= int(data[num+1])
       elif 'dimensions' in line.lower():
@@ -210,7 +210,7 @@ class ConvertMorphologikaLandmarksLogic(ScriptedLoadableModuleLogic):
       elif 'rawpoints' in line.lower():
         rawIndex = num
 
-    #Check that size variables were found	
+    #Check that size variables were found
     if subjectNumber==0 or landmarkNumber==0 or dimensionNumber==0:
       print("Error reading file: can not read size")
 
@@ -221,18 +221,18 @@ class ConvertMorphologikaLandmarksLogic(ScriptedLoadableModuleLogic):
     subjectList=data[nameIndex+1:nameIndex+1+subjectNumber]
     rawData = data[rawIndex+1:len(data)] # get raw data portion of file
     rawData = [ line for line in rawData if not ("\'" in line or "\n" == line)] # remove spaces and names
-      
-    if len(rawData) != subjectNumber*landmarkNumber:    # check for error in landmark import 
+
+    if len(rawData) != subjectNumber*landmarkNumber:    # check for error in landmark import
       print("Error reading file: incorrect landmark number")
     else:
       fiducialNode = slicer.vtkMRMLMarkupsFiducialNode() # Create a markups node for imported points
       for index, subject in enumerate(subjectList): # iterate through each subject
-        
+
         for landmark in range(landmarkNumber):
           lineData = rawData.pop(0).split() #get first line and split by whitespace
           coordinates = [float(lineData[0]), float(lineData[1]), float(lineData[2])]
           fiducialNode.AddFiducialFromArray(coordinates, str(landmark)) #insert fiducial named by landmark number
-        
+
         slicer.mrmlScene.AddNode(fiducialNode)
         fiducialNode.SetName(subject.split()[0]) # set name to subject name, removing new line char
         path = os.path.join(outputDirectory, subject.split()[0] + '.fcsv')

--- a/GPA/GPA.py
+++ b/GPA/GPA.py
@@ -173,9 +173,9 @@ class LMData:
     self.shift=tmp
 
   def writeOutData(self,outputFolder,files):
-    
-    
-    
+
+
+
     # make headers for eigenvector matrix
     headerPC=[]
     headerLM=[""]
@@ -185,13 +185,13 @@ class LMData:
       headerLM.append("LM "+str(i+1)+"_X")
       headerLM.append("LM "+str(i+1)+"_Y")
       headerLM.append("LM "+str(i+1)+"_Z")
-      
+
     temp = np.vstack((np.array(headerPC),self.vec))
     temp = np.column_stack((np.array(headerLM),temp))
     np.savetxt(outputFolder+os.sep+"eigenvector.csv", temp, delimiter=",",fmt='%s')
     temp = np.column_stack((np.array(headerPC),self.val))
     np.savetxt(outputFolder+os.sep+"eigenvalues.csv", temp, delimiter=",",fmt='%s')
-   
+
     headerLM=[]
     headerCoordinate = ["","X","Y","Z"]
     for i in range(len(self.mShape)):
@@ -199,7 +199,7 @@ class LMData:
     temp = np.column_stack((np.array(headerLM),self.mShape))
     temp = np.vstack((np.array(headerCoordinate),temp))
     np.savetxt(outputFolder+os.sep+"MeanShape.csv", temp, delimiter=",",fmt='%s')
-   
+
     percentVar=self.val/self.val.sum()
     self.procdist=gpa_lib.procDist(self.lm, self.mShape)
     files=np.array(files)
@@ -315,7 +315,7 @@ class GPAWidget(ScriptedLoadableModuleWidget):
     threeDView = threeDWidget.threeDView()
     threeDView.resetCamera()
     threeDView.resetFocalPoint()
-    
+
     # check for loaded reference model
     if hasattr(self, 'modelDisplayNode'):
       # assign each model to a specific view
@@ -326,7 +326,7 @@ class GPAWidget(ScriptedLoadableModuleWidget):
       referenceModelNode = self.meanLandmarkNode
     # fit the red slice node to show the plot projections
     redNode = layoutManager.sliceWidget('Red').sliceView().mrmlSliceNode()
-    
+
     rasBounds = [0,]*6
     referenceModelNode.GetRASBounds(rasBounds)
     redNode.GetSliceToRAS().SetElement(0, 3, (rasBounds[1]+rasBounds[0]) / 2.)
@@ -437,12 +437,12 @@ class GPAWidget(ScriptedLoadableModuleWidget):
     if self.meanLandmarkNode is None:
       self.meanLandmarkNode = slicer.vtkMRMLMarkupsFiducialNode()
       self.meanLandmarkNode.SetName('Mean Landmark Node')
-      self.meanLandmarkNode.SetHideFromEditors(1) #hide from module so these cannot be selected for analysis 
+      self.meanLandmarkNode.SetHideFromEditors(1) #hide from module so these cannot be selected for analysis
       slicer.mrmlScene.AddNode(self.meanLandmarkNode)
       GPANodeCollection.AddItem(self.meanLandmarkNode)
       modelDisplayNode = slicer.mrmlScene.AddNewNodeByClass('vtkMRMLModelDisplayNode')
       GPANodeCollection.AddItem(modelDisplayNode)
-      
+
     for landmarkNumber in range (shape[0]):
       name = str(landmarkNumber+1) #start numbering at 1
       self.meanLandmarkNode.AddFiducialFromArray(self.rawMeanLandmarks[landmarkNumber,:], name)
@@ -516,24 +516,24 @@ class GPAWidget(ScriptedLoadableModuleWidget):
     #add table to new layout
     slicer.app.applicationLogic().GetSelectionNode().SetReferenceActiveTableID(tableNode.GetID())
     slicer.app.applicationLogic().PropagateTableSelection()
-    
+
   def factorStringChanged(self):
-    if self.factorName.text is not "": 
+    if self.factorName.text is not "":
       self.inputFactorButton.enabled = True
-    else: 
+    else:
       self.inputFactorButton.enabled = False
-      
+
   def enterFactors(self):
     sortedArray = np.zeros(len(self.files), dtype={'names':('filename', 'procdist'),'formats':('U10','f8')})
     sortedArray['filename']=self.files
-    
+
     #check for an existing factor table
     if not hasattr(self, 'factorTableNode'):
       print("No table yet, creating now:")
       self.factorTableNode = slicer.mrmlScene.AddNewNodeByClass('vtkMRMLTableNode', 'Factor Table')
       GPANodeCollection.AddItem(self.factorTableNode)
       col1=self.factorTableNode.AddColumn()
-      col1.SetName('ID')   
+      col1.SetName('ID')
       for i in range(len(self.files)):
        self.factorTableNode.AddEmptyRow()
        self.factorTableNode.SetCellText(i,0,sortedArray['filename'][i])
@@ -541,16 +541,16 @@ class GPAWidget(ScriptedLoadableModuleWidget):
     col2=self.factorTableNode.AddColumn()
     col2.SetName(self.factorName.text)
     self.selectFactor.addItem(self.factorName.text)
-   
+
     #add table to new layout
     slicer.app.applicationLogic().GetSelectionNode().SetReferenceActiveTableID(self.factorTableNode.GetID())
     slicer.app.applicationLogic().PropagateTableSelection()
     self.factorTableNode.GetTable().Modified()
-    
+
     #reset text field for names
     self.factorName.setText("")
     self.inputFactorButton.enabled = False
-    
+
   def plot(self):
     logic = GPALogic()
     # get values from boxs
@@ -563,7 +563,7 @@ class GPAWidget(ScriptedLoadableModuleWidget):
     for i in range(25):
       data=gpa_lib.plotTanProj(self.LM.lm,i,1)
       dataAll[:,i] = data[:,0]
-    
+
     factorIndex = self.selectFactor.currentIndex
     if (factorIndex > 0) and hasattr(self, 'factorTableNode') and (self.factorTableNode.GetNumberOfColumns()>factorIndex):
       factorCol = self.factorTableNode.GetTable().GetColumn(factorIndex)
@@ -594,10 +594,10 @@ class GPAWidget(ScriptedLoadableModuleWidget):
       referenceLandmarks = self.sourceLMnumpyTransformed
       if self.TwoDLM.isChecked():
         if self.modelDisplayNode is not None:
-          self.modelDisplayNode.SetSliceProjection(1) 
-          self.modelDisplayNode.SetSliceProjectionOpacity(1) 
+          self.modelDisplayNode.SetSliceProjection(1)
+          self.modelDisplayNode.SetSliceProjectionOpacity(1)
         else:
-          self.modelDisplayNode.SetSliceProjection(0) 
+          self.modelDisplayNode.SetSliceProjection(0)
     except AttributeError:
       referenceLandmarks = self.rawMeanLandmarks
       # get fiducial node for mean landmarks
@@ -625,10 +625,10 @@ class GPAWidget(ScriptedLoadableModuleWidget):
     self.vectorThree.clear()
     self.XcomboBox.clear()
     self.YcomboBox.clear()
-    
+
     self.scaleSlider.value=3
     self.scaleMeanShapeSlider.value=3
-    self.meanShapeColor.color=qt.QColor(255,0,0) 
+    self.meanShapeColor.color=qt.QColor(255,0,0)
 
     self.nodeCleanUp()
 
@@ -655,10 +655,10 @@ class GPAWidget(ScriptedLoadableModuleWidget):
     self.selectFactor.clear()
     self.factorName.setText("")
     self.scaleSlider.value=3
-    
+
     self.scaleMeanShapeSlider.value=3
-    self.meanShapeColor.color=qt.QColor(255,0,0)    
-    
+    self.meanShapeColor.color=qt.QColor(255,0,0)
+
     # Disable buttons for workflow
     self.plotButton.enabled = False
     self.inputFactorButton.enabled = False
@@ -667,48 +667,48 @@ class GPAWidget(ScriptedLoadableModuleWidget):
     self.plotMeanButton3D.enabled = False
     self.plotMeanButton2D.enabled = False
     self.loadButton.enabled = False
-    
+
     #delete data from previous runs
     self.nodeCleanUp()
 
   def nodeCleanUp(self):
     # clear all nodes created by the module
     for node in GPANodeCollection:
-      
+
       GPANodeCollection.RemoveItem(node)
       slicer.mrmlScene.RemoveNode(node)
-  
+
   def toggleMeanPlot(self):
-    visibility = self.meanLandmarkNode.GetDisplayVisibility() 
+    visibility = self.meanLandmarkNode.GetDisplayVisibility()
     if visibility:
       visibility = self.meanLandmarkNode.SetDisplayVisibility(False)
     else:
       visibility = self.meanLandmarkNode.SetDisplayVisibility(True)
       #refresh color and scale from GUI
-      self.meanLandmarkNode.GetDisplayNode().SetGlyphScale(self.scaleMeanShapeSlider.value) 
+      self.meanLandmarkNode.GetDisplayNode().SetGlyphScale(self.scaleMeanShapeSlider.value)
       color = self.meanShapeColor.color
-      self.meanLandmarkNode.GetDisplayNode().SetSelectedColor([color.red()/255,color.green()/255,color.blue()/255]) 
-      
+      self.meanLandmarkNode.GetDisplayNode().SetSelectedColor([color.red()/255,color.green()/255,color.blue()/255])
+
   def toggleMeanPlot2D(self):
-    visibility = self.meanLandmarkNode.GetDisplayNode().GetSliceProjection() 
+    visibility = self.meanLandmarkNode.GetDisplayNode().GetSliceProjection()
     if visibility:
-      self.meanLandmarkNode.GetDisplayNode().SetSliceProjection(0) 
+      self.meanLandmarkNode.GetDisplayNode().SetSliceProjection(0)
     else:
-      self.meanLandmarkNode.GetDisplayNode().SetSliceProjection(1) 
-      self.meanLandmarkNode.GetDisplayNode().SetSliceProjectionOpacity(1) 
+      self.meanLandmarkNode.GetDisplayNode().SetSliceProjection(1)
+      self.meanLandmarkNode.GetDisplayNode().SetSliceProjectionOpacity(1)
       #refresh color and scale from GUI
-      self.meanLandmarkNode.GetDisplayNode().SetGlyphScale(self.scaleMeanShapeSlider.value)   
+      self.meanLandmarkNode.GetDisplayNode().SetGlyphScale(self.scaleMeanShapeSlider.value)
       color = self.meanShapeColor.color
-      self.meanLandmarkNode.GetDisplayNode().SetSelectedColor([color.red()/255,color.green()/255,color.blue()/255]) 
-      
+      self.meanLandmarkNode.GetDisplayNode().SetSelectedColor([color.red()/255,color.green()/255,color.blue()/255])
+
   def toggleMeanColor(self):
     color = self.meanShapeColor.color
-    self.meanLandmarkNode.GetDisplayNode().SetSelectedColor([color.red()/255,color.green()/255,color.blue()/255]) 
-    
+    self.meanLandmarkNode.GetDisplayNode().SetSelectedColor([color.red()/255,color.green()/255,color.blue()/255])
+
   def scaleMeanGlyph(self):
     scaleFactor = self.sampleSizeScaleFactor/10
-    self.meanLandmarkNode.GetDisplayNode().SetGlyphScale(self.scaleMeanShapeSlider.value) 
-    
+    self.meanLandmarkNode.GetDisplayNode().SetGlyphScale(self.scaleMeanShapeSlider.value)
+
   def setup(self):
     ScriptedLoadableModuleWidget.setup(self)
     self.StyleSheet="font: 12px;  min-height: 20 px ; background-color: qlineargradient(x1: 0, y1: 0, x2: 0, y2: 1, stop: 0 #f6f7fa, stop: 1 #dadbde); border: 1px solid; border-radius: 4px; "
@@ -760,10 +760,10 @@ class GPAWidget(ScriptedLoadableModuleWidget):
     meanShapeFrame.text="Mean Shape Plot Options"
     meanShapeLayout= qt.QGridLayout(meanShapeFrame)
     self.layout.addWidget(meanShapeFrame)
-    
+
     meanButtonLable=qt.QLabel("Mean shape visibility: ")
     meanShapeLayout.addWidget(meanButtonLable,1,1)
-    
+
     self.plotMeanButton3D = qt.QPushButton("Toggle mean shape visibility")
     self.plotMeanButton3D.checkable = True
     self.plotMeanButton3D.setStyleSheet(self.StyleSheet)
@@ -771,7 +771,7 @@ class GPAWidget(ScriptedLoadableModuleWidget):
     meanShapeLayout.addWidget(self.plotMeanButton3D,1,2,1,1)
     self.plotMeanButton3D.enabled = False
     self.plotMeanButton3D.connect('clicked(bool)', self.toggleMeanPlot)
-    
+
     self.plotMeanButton2D = qt.QPushButton("Toggle 2D projection")
     self.plotMeanButton2D.checkable = True
     self.plotMeanButton2D.setStyleSheet(self.StyleSheet)
@@ -779,7 +779,7 @@ class GPAWidget(ScriptedLoadableModuleWidget):
     meanShapeLayout.addWidget(self.plotMeanButton2D,1,3,1,1)
     self.plotMeanButton2D.enabled = False
     self.plotMeanButton2D.connect('clicked(bool)', self.toggleMeanPlot2D)
-    
+
     meanColorLable=qt.QLabel("Mean shape color: ")
     meanShapeLayout.addWidget(meanColorLable,2,1)
     self.meanShapeColor = ctk.ctkColorPickerButton()
@@ -787,8 +787,8 @@ class GPAWidget(ScriptedLoadableModuleWidget):
     self.meanShapeColor.color = qt.QColor(255,0,0)
     meanShapeLayout.addWidget(self.meanShapeColor,2,2,1,1)
     self.meanShapeColor.connect('colorChanged(QColor)', self.toggleMeanColor)
-    
-    
+
+
     self.scaleMeanShapeSlider = ctk.ctkSliderWidget()
     self.scaleMeanShapeSlider.singleStep = .1
     self.scaleMeanShapeSlider.minimum = 0
@@ -799,7 +799,7 @@ class GPAWidget(ScriptedLoadableModuleWidget):
     meanShapeLayout.addWidget(meanShapeSliderLabel,3,1)
     meanShapeLayout.addWidget(self.scaleMeanShapeSlider,3,2,1,2)
     self.scaleMeanShapeSlider.connect('valueChanged(double)', self.scaleMeanGlyph)
-    
+
     #PC plot section
     plotFrame=ctk.ctkCollapsibleButton()
     plotFrame.text="PCA Scatter Plot Options"
@@ -815,14 +815,14 @@ class GPAWidget(ScriptedLoadableModuleWidget):
     Ylabel=qt.QLabel("Y Axis")
     plotLayout.addWidget(Ylabel,2,1)
     plotLayout.addWidget(self.YcomboBox,2,2,1,3)
-    
+
     self.factorNameLabel=qt.QLabel('Factor Name:')
     plotLayout.addWidget(self.factorNameLabel,3,1)
     self.factorName=qt.QLineEdit()
     self.factorName.setToolTip("Enter factor name")
     self.factorName.connect('textChanged(const QString &)', self.factorStringChanged)
     plotLayout.addWidget(self.factorName,3,2)
-    
+
     self.inputFactorButton = qt.QPushButton("Add factor data")
     self.inputFactorButton.checkable = True
     self.inputFactorButton.setStyleSheet(self.StyleSheet)
@@ -830,7 +830,7 @@ class GPAWidget(ScriptedLoadableModuleWidget):
     plotLayout.addWidget(self.inputFactorButton,3,4)
     self.inputFactorButton.enabled = False
     self.inputFactorButton.connect('clicked(bool)', self.enterFactors)
-    
+
     self.selectFactor=qt.QComboBox()
     self.selectFactor.addItem("No factor data")
     selectFactorLabel=qt.QLabel("Select factor: ")
@@ -870,8 +870,8 @@ class GPAWidget(ScriptedLoadableModuleWidget):
     self.TwoDType=qt.QCheckBox()
     self.TwoDType.checked = False
     self.TwoDType.setText("Lollipop 2D Projection")
-    lolliLayout.addWidget(self.TwoDType,4,2)   
-    
+    lolliLayout.addWidget(self.TwoDType,4,2)
+
     self.lolliButton = qt.QPushButton("Lollipop Vector Plot")
     self.lolliButton.checkable = True
     self.lolliButton.setStyleSheet(self.StyleSheet)
@@ -921,7 +921,7 @@ class GPAWidget(ScriptedLoadableModuleWidget):
     distributionLayout.addWidget(self.plotDistributionButton,7,1,1,4)
     self.plotDistributionButton.enabled = False
     self.plotDistributionButton.connect('clicked(bool)', self.onPlotDistribution)
-    
+
     # 3D view set up tab
     selectTemplatesButton=ctk.ctkCollapsibleButton()
     selectTemplatesButton.text="Setup 3D Visualization"
@@ -967,7 +967,7 @@ class GPAWidget(ScriptedLoadableModuleWidget):
     self.selectorButton.connect('clicked(bool)', self.onSelect)
 
     self.layout.addWidget(selectTemplatesButton)
-    
+
     # PC warping
     vis=ctk.ctkCollapsibleButton()
     vis.text='PCA Visualization Parameters'
@@ -1004,7 +1004,7 @@ class GPAWidget(ScriptedLoadableModuleWidget):
     animateLayout.addWidget(self.stopRecordButton,1,5,1,2)
     self.stopRecordButton.connect('clicked(bool)', self.onStopRecording)
     self.layout.addWidget(animate)
-    
+
     # Reset button
     resetButton = qt.QPushButton("Reset Scene")
     resetButton.checkable = True
@@ -1021,8 +1021,8 @@ class GPAWidget(ScriptedLoadableModuleWidget):
     modelSequence.SetHideFromEditors(0)
     transformSequence = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLSequenceNode","GPATFSequence")
     transformSequence.SetHideFromEditors(0)
-    
-    #Set up a new sequence browser and add sequences 
+
+    #Set up a new sequence browser and add sequences
     browserNode = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLSequenceBrowserNode", "GPASequenceBrowser")
     browserLogic=slicer.modules.sequencebrowser.logic()
     browserLogic.AddSynchronizedNode(modelSequence,self.cloneModelNode,browserNode)
@@ -1038,16 +1038,16 @@ class GPAWidget(ScriptedLoadableModuleWidget):
     GPANodeCollection.AddItem(modelSequence)
     GPANodeCollection.AddItem(transformSequence)
     GPANodeCollection.AddItem(browserNode)
-    
+
     #enable stop recording
     self.stopRecordButton.enabled = True
-  
+
   def onStopRecording(self):
     browserWidget=slicer.modules.sequencebrowser.widgetRepresentation()
     recordWidget = browserWidget.findChild('qMRMLSequenceBrowserPlayWidget')
     recordWidget.setRecordingEnabled(0)
     slicer.util.selectModule(slicer.modules.sequencebrowser)
-    
+
   def cleanup(self):
     pass
 
@@ -1217,7 +1217,7 @@ class GPAWidget(ScriptedLoadableModuleWidget):
     if modelNode is None:
       modelNode = slicer.vtkMRMLModelNode()
       modelNode.SetName('Landmark Point Cloud')
-      modelNode.SetHideFromEditors(1) #hide from module so these cannot be selected for analysis 
+      modelNode.SetHideFromEditors(1) #hide from module so these cannot be selected for analysis
       slicer.mrmlScene.AddNode(modelNode)
       GPANodeCollection.AddItem(modelNode)
       modelDisplayNode = slicer.mrmlScene.AddNewNodeByClass('vtkMRMLModelDisplayNode')
@@ -1279,7 +1279,7 @@ class GPAWidget(ScriptedLoadableModuleWidget):
       if modelNode is None:
         modelNode = slicer.vtkMRMLModelNode()
         modelNode.SetName('Landmark Variance Ellipse')
-        modelNode.SetHideFromEditors(1) #hide from module so these cannot be selected for analysis 
+        modelNode.SetHideFromEditors(1) #hide from module so these cannot be selected for analysis
         slicer.mrmlScene.AddNode(modelNode)
         GPANodeCollection.AddItem(modelNode)
         modelDisplayNode = slicer.mrmlScene.AddNewNodeByClass('vtkMRMLModelDisplayNode')
@@ -1299,7 +1299,7 @@ class GPAWidget(ScriptedLoadableModuleWidget):
         GPANodeCollection.AddItem(modelNode)
         modelDisplayNode = slicer.mrmlScene.AddNewNodeByClass('vtkMRMLModelDisplayNode')
         modelNode.SetAndObserveDisplayNodeID(modelDisplayNode.GetID())
-        
+
         GPANodeCollection.AddItem(modelDisplayNode)
 
     sphereSource = vtk.vtkSphereSource()
@@ -1506,7 +1506,7 @@ class GPALogic(ScriptedLoadableModuleLogic):
           np.delete(landmarksControl,i,axis=2)
 
     return landmarksControl, files
-    
+
   def dist(self, a):
     """
     Computes the euclidean distance matrix for nXK points in a 3D space. So the input matrix is nX3xk
@@ -1539,7 +1539,7 @@ class GPALogic(ScriptedLoadableModuleLogic):
     numPoints = len(data)
     uniqueFactors = np.unique(factors)
     factorNumber = len(uniqueFactors)
-    
+
     #Set up chart
     plotChartNode=slicer.mrmlScene.GetFirstNodeByName("Chart_PCA_cov" + xAxis + "v" +yAxis)
     if plotChartNode is None:
@@ -1547,8 +1547,8 @@ class GPALogic(ScriptedLoadableModuleLogic):
       GPANodeCollection.AddItem(plotChartNode)
     else:
       plotChartNode.RemoveAllPlotSeriesNodeIDs()
-     
-    # Plot all series 
+
+    # Plot all series
     for factor in uniqueFactors:
       tableNode=slicer.mrmlScene.GetFirstNodeByName('PCA Scatter Plot Table Factor ' + factor)
       if tableNode is None:
@@ -1556,27 +1556,27 @@ class GPALogic(ScriptedLoadableModuleLogic):
         GPANodeCollection.AddItem(tableNode)
       else:
         tableNode.RemoveAllColumns()    #clear previous data from columns
-    
-      # Set up columns for X,Y, and labels  
+
+      # Set up columns for X,Y, and labels
       labels=tableNode.AddColumn()
       labels.SetName('Subject ID')
       tableNode.SetColumnType('Subject ID',vtk.VTK_STRING)
-    
+
       for i in range(pcNumber):
         pc=tableNode.AddColumn()
         colName="PC" + str(i+1)
         pc.SetName(colName)
         tableNode.SetColumnType(colName, vtk.VTK_FLOAT)
-      
+
       factorCounter=0
       for i in range(numPoints):
-        if (factors[i] == factor):      
+        if (factors[i] == factor):
           tableNode.AddEmptyRow()
           tableNode.SetCellText(factorCounter, 0,files[i])
           for j in range(pcNumber):
             tableNode.SetCellText(factorCounter, j+1, str(data[i,j]))
           factorCounter+=1
-          
+
       plotSeriesNode=slicer.mrmlScene.GetFirstNodeByName("Series_PCA_" + factor + "_" + xAxis + "v" +yAxis)
       if plotSeriesNode is None:
         plotSeriesNode = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLPlotSeriesNode", factor)
@@ -1592,7 +1592,7 @@ class GPALogic(ScriptedLoadableModuleLogic):
       plotSeriesNode.SetUniqueColor()
       # Add data series to chart
       plotChartNode.AddAndObservePlotSeriesNodeID(plotSeriesNode.GetID())
-    
+
     # Set up view options for chart
     plotChartNode.SetTitle('PCA Scatter Plot with factors')
     plotChartNode.SetXAxisTitle(xAxis)
@@ -1602,7 +1602,7 @@ class GPALogic(ScriptedLoadableModuleLogic):
     plotWidget = layoutManager.plotWidget(0)
     plotViewNode = plotWidget.mrmlPlotViewNode()
     plotViewNode.SetPlotChartNodeID(plotChartNode.GetID())
-      
+
   def makeScatterPlot(self, data, files, title,xAxis,yAxis,pcNumber):
     numPoints = len(data)
     #check if there is a table node has been created
@@ -1711,7 +1711,7 @@ class GPALogic(ScriptedLoadableModuleLogic):
       if modelNode is None:
         modelNode = slicer.vtkMRMLModelNode()
         modelNode.SetName(modelNodeName)
-        modelNode.SetHideFromEditors(1) #hide from module so these cannot be selected for analysis 
+        modelNode.SetHideFromEditors(1) #hide from module so these cannot be selected for analysis
         slicer.mrmlScene.AddNode(modelNode)
         GPANodeCollection.AddItem(modelNode)
         modelDisplayNode = slicer.mrmlScene.AddNewNodeByClass('vtkMRMLModelDisplayNode')

--- a/GPA/Support/gpa_lib.py
+++ b/GPA/Support/gpa_lib.py
@@ -6,8 +6,8 @@ import fnmatch
 def centerShape(shape):
     shape=shape-shape.mean(axis=0)
     return shape
-    
-#scale shape by divinding by frobinius norm    
+
+#scale shape by divinding by frobinius norm
 def scaleShape(shape):
     shape=shape/np.linalg.norm(shape)
     return shape
@@ -20,29 +20,29 @@ def alignShape(refShape,shape):
     u,s,v=np.linalg.svd(np.dot(np.transpose(refShape),shape), full_matrices=True)
     rotationMatrix=np.dot(np.transpose(v), np.transpose(u))
     shape=np.dot(shape,rotationMatrix)
-    
+
     return shape
 
 def procrustesAlign(refShape,shape):
    #center both shapes
     refShape=centerShape(refShape)
     shape=centerShape(shape)
-    
+
     #scale both shapes
     refShape=scaleShape(refShape)
     shape=scaleShape(shape)
-    
+
     # rotate shape to match the refshape
     shape=alignShape(refShape,shape)
-    
+
     return shape
-    
+
 def procrustesAlignNoScale(refShape,shape):
    #center both shapes
     refShape=centerShape(refShape)
     shape=centerShape(shape)
     shape=alignShape(refShape,shape)
-    
+
     return shape
 
 # <codecell>
@@ -87,7 +87,7 @@ def makeTransformMatrix(ePair,pcA,pcB):
     i=i[0]
     vec1=ePair[pcA][0][1]
     vec2=ePair[pcB][0][1]
-    
+
     transform=np.zeros((i,2))
     transform[:,0]=vec1.reshape(i).real
     transform[:,1]=vec2.reshape(i).real
@@ -105,7 +105,7 @@ def plotTanProj(monsters,pcA,pcB):
     tmp=np.column_stack((coords[0,:],coords[1,:]))
     return tmp
 
-#GPA 
+#GPA
 def meanShape(monsters):
     return monsters.mean(axis=2)
 
@@ -114,17 +114,17 @@ def alignToOne(monsters):
     #scale and center the first monster
     monsters[:,:,0]=centerShape(monsters[:,:,0])
     monsters[:,:,0]=scaleShape(monsters[:,:,0])
-    
+
     #align other monster to it
     for x in range(1,k):
         monsters[:,:,x]=procrustesAlign(monsters[:,:,0],monsters[:,:,x])
-          
+
     return monsters
 def alignToOneNoScale(monsters):
     i,j,k=monsters.shape
     #scale and center the first monster
     monsters[:,:,0]=centerShape(monsters[:,:,0])
-    
+
     #align other monster to it
     for x in range(1,k):
         monsters[:,:,x]=procrustesAlignNoScale(monsters[:,:,0],monsters[:,:,x])
@@ -136,26 +136,26 @@ def alignToMean(monsters,trys):
     for x in range(k):
         monsters[:,:,x]=procrustesAlign(mean1,monsters[:,:,x])
     mean2=meanShape(monsters)
-    
+
     diff=np.linalg.norm(mean1-mean2)
     trys=trys+1
     if diff>.00001 and trys< 50:
         alignToMean(monsters, trys)
-    
+
     return monsters
-    
+
 def alignToMeanNoScale(monsters,trys):
     mean1=meanShape(monsters)
     i,j,k=monsters.shape
     for x in range(k):
         monsters[:,:,x]=procrustesAlignNoScale(mean1,monsters[:,:,x])
     mean2=meanShape(monsters)
-    
+
     diff=np.linalg.norm(mean1-mean2)
     trys=trys+1
     if diff>.00001 and trys< 50:
         alignToMeanNoScale(monsters, trys)
-    
+
     return monsters
 
 def centSize(monsters):
@@ -171,36 +171,36 @@ def doGPA(monsters):
     monsters=alignToMean(monsters,1)
     mShape=meanShape(monsters)
     return monsters, mShape
- 
+
 def doGPANoScale(monsters):
     monsters=alignToOneNoScale(monsters)
     mShape=meanShape(monsters)
     monsters=alignToMeanNoScale(monsters,1)
     mShape=meanShape(monsters)
-    return monsters, mShape 
+    return monsters, mShape
 
 def procDist(monsters,mshape):
     i,j,k=monsters.shape
-    
+
     procDists=np.zeros(k)
     for x in range(k):
         tmp=monsters[:,:,x]-mshape
         procDists[x]=np.linalg.norm(tmp,'fro')
-        
+
     return procDists
 
 def procDistPP(monsters):
     i,j,k=monsters.shape
-    
+
     procDists=np.zeros((k,k))
     for x in range(k):
         for y in range(k):
             tmp=monsters[:,:,x]-monsters[:,:,y]
             procDists[x,y]=np.linalg.norm(tmp,'fro')
-        
+
     return procDists
-        
-        
+
+
 
 
 def makeTwoDim2(monsters):

--- a/GPA/Support/vtk_lib.py
+++ b/GPA/Support/vtk_lib.py
@@ -44,7 +44,7 @@ transform: vtkAbstractTransform
 
 def createTPS( sourceLM, targetLM):
     """Perform the thin plate transform using the vtkThinPlateSplineTransform class"""
-# 
+#
     thinPlateTransform = vtk.vtkThinPlateSplineTransform()
     thinPlateTransform.SetBasisToR() # for 3D transform
 #
@@ -61,16 +61,16 @@ def convertFudicialToVTKPoint(fnode):
     x=y=z=0
     loc=[x,y,z]
     lmData=np.zeros((numberOfLM,3))
-    # 
+    #
     for i in range(numberOfLM):
         fnode.GetNthFiducialPosition(i,loc)
         lmData[i,:]=np.asarray(loc)
     #return lmData
-    # 
+    #
     points=vtk.vtkPoints()
     for i in range(numberOfLM):
         points.InsertNextPoint(lmData[i,0], lmData[i,1], lmData[i,2])
-# 
+#
     return points
 
 def convertNumpyToVTK(A):
@@ -78,7 +78,7 @@ def convertNumpyToVTK(A):
     points=vtk.vtkPoints()
     for i in range(x):
         points.InsertNextPoint(A[i,0], A[i,1], A[i,2])
-# 
+#
     return points
 
 
@@ -86,16 +86,16 @@ def convertNumpyToVTK(A):
 #     mrml=slicer.mrmlScene
 #     tnode=slicer.vtkMRMLScalarVolumeNode()
 #     mrml.AddNode(tnode)
-# # 
+# #
 #     movingNode=getNode('3958-f_baseline')
 #     movingLM=getNode('3958-f_baseline-landmarks')
-# # 
+# #
 #     fixedNode=getNode('3964-m_baseline')
 #     fixedLM=getNode('3964-m_baseline-landmarks')
-#     # 
+#     #
 #     fixedPoints=convertFudicialToVTKPoint(fixedLM)
 #     movingPoints=convertFudicialToVTKPoint(movingLM)
-#     # 
+#     #
 #     performThinPlateRegistration(movingNode, fixedNode, fixedPoints,movingPoints,movingNode)
 
 
@@ -123,4 +123,4 @@ def convertNumpyToVTK(A):
 # >>> tnode.SetAndObserveTransformToParent(tps3.Inverse())
 # >>> tps3.SetTargetLandmarks(mLM)
 # >>> tps3.SetTargetLandmarks(fLM)
-# >>>  
+# >>>

--- a/ImportSurfaceToSegment/ImportSurfaceToSegment.py
+++ b/ImportSurfaceToSegment/ImportSurfaceToSegment.py
@@ -20,14 +20,14 @@ class ImportSurfaceToSegment(ScriptedLoadableModule):
     self.parent.dependencies = []
     self.parent.contributors = ["Sara Rolfe (UW), Murat Maga (UW)"] # replace with "Firstname Lastname (Organization)"
     self.parent.helpText = """
-This module imports a surface image and converts it to a segmentation for editing. If the default segmentation produced by this module is not sufficient, 
+This module imports a surface image and converts it to a segmentation for editing. If the default segmentation produced by this module is not sufficient,
 please see the Segmentations module Export to Files tab to set advanced settings.
 """
     self.parent.helpText += self.getDefaultModuleDocumentationLink()
     self.parent.acknowledgementText = """
-This module was developed by Sara Rolfe and Murat Maga, through a NSF ABI Development grant, "An Integrated Platform for Retrieval, Visualization and Analysis of 
+This module was developed by Sara Rolfe and Murat Maga, through a NSF ABI Development grant, "An Integrated Platform for Retrieval, Visualization and Analysis of
 3D Morphology From Digital Biological Collections" (Award Numbers: 1759883 (Murat Maga), 1759637 (Adam Summers), 1759839 (Douglas Boyer)).
-https://nsf.gov/awardsearch/showAward?AWD_ID=1759883&HistoricalAwards=false 
+https://nsf.gov/awardsearch/showAward?AWD_ID=1759883&HistoricalAwards=false
 """ # replace with organization, grant and thanks.
 
 #
@@ -80,7 +80,7 @@ class ImportSurfaceToSegmentWidget(ScriptedLoadableModuleWidget):
     # connections
     self.applyButton.connect('clicked(bool)', self.onApplyButton)
     self.inputFileSelector.connect('validInputChanged(bool)', self.onSelectInput)
- 
+
     # Add vertical spacer
     self.layout.addStretch(1)
 
@@ -92,7 +92,7 @@ class ImportSurfaceToSegmentWidget(ScriptedLoadableModuleWidget):
     pass
 
   def onSelectInput(self):
-    self.applyButton.enabled = bool(self.inputFileSelector.currentPath) 
+    self.applyButton.enabled = bool(self.inputFileSelector.currentPath)
 
 
   def onApplyButton(self):
@@ -190,7 +190,7 @@ class ImportSurfaceToSegmentLogic(ScriptedLoadableModuleLogic):
     labelName = modelNode.GetName() + '-labelmap'
     labelmapNode = slicer.mrmlScene.AddNewNodeByClass('vtkMRMLLabelMapVolumeNode', labelName)
     slicer.modules.segmentations.logic().ExportAllSegmentsToLabelmapNode(segmentNode, labelmapNode)
-    
+
     # Set up interface for editing
     slicer.util.selectModule(slicer.modules.segmenteditor)
     editorWidget=slicer.modules.segmenteditor.widgetRepresentation()
@@ -199,7 +199,7 @@ class ImportSurfaceToSegmentLogic(ScriptedLoadableModuleLogic):
     qWidget.setCurrentSegmentID(segmentID)
     qWidget.setMasterVolumeNode(labelmapNode)
     #remove original model Node
-    slicer.mrmlScene.RemoveNode(modelNode)  
+    slicer.mrmlScene.RemoveNode(modelNode)
     logging.info('Processing completed')
 
     return True

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ To install SlicerMorph, please first install the Preview Release of [3D-Slicer](
 - **SkyscanReconImport:** Imports an image stack from Bruker/Skyscan reconstruction software (Nrecon) with correct voxel spacing and orientation as a 3D volume.
 
 ## Funding Acknowledgement
-This project is supported by a NSF Advances in Biological Informatics Collaborative grant to Murat Maga (ABI-1759883), Adam Summers (ABI-1759637) and Doug Boyer (ABI-1759839). 
+This project is supported by a NSF Advances in Biological Informatics Collaborative grant to Murat Maga (ABI-1759883), Adam Summers (ABI-1759637) and Doug Boyer (ABI-1759839).
 
 <img src="./NSF_4-Color_bitmap_Logo.png" alt="NSF logo" width="256" height="256">
 

--- a/ReadLandmarkFile/ReadLandmarkFile.py
+++ b/ReadLandmarkFile/ReadLandmarkFile.py
@@ -21,13 +21,13 @@ class ReadLandmarkFile(ScriptedLoadableModule):
     self.parent.contributors = ["Murat Maga (UW), Sara Rolfe (UW)"] # replace with "Firstname Lastname (Organization)"
     self.parent.helpText = """
 This module imports an image sequence into Slicer as a 3D volume. Accepted formats are TIF, PNG, JPG and BMP. For DICOMS, use the DICOM module.
-User can optionally perform downsampling of the volume at the time of import. For specific use cases and options, 
+User can optionally perform downsampling of the volume at the time of import. For specific use cases and options,
 """
     self.parent.helpText += self.getDefaultModuleDocumentationLink()
     self.parent.acknowledgementText = """
-This module was developed by Sara Rolfe and Murat Maga, through a NSF ABI Development grant, "An Integrated Platform for Retrieval, Visualization and Analysis of 
+This module was developed by Sara Rolfe and Murat Maga, through a NSF ABI Development grant, "An Integrated Platform for Retrieval, Visualization and Analysis of
 3D Morphology From Digital Biological Collections" (Award Numbers: 1759883 (Murat Maga), 1759637 (Adam Summers), 1759839 (Douglas Boyer)).
-https://nsf.gov/awardsearch/showAward?AWD_ID=1759883&HistoricalAwards=false 
+https://nsf.gov/awardsearch/showAward?AWD_ID=1759883&HistoricalAwards=false
 """ # replace with organization, grant and thanks.
 
 #
@@ -60,7 +60,7 @@ class ReadLandmarkFileWidget(ScriptedLoadableModuleWidget):
     self.inputFileSelector = ctk.ctkPathLineEdit()
     self.inputFileSelector.setToolTip( "Select landmark file for import" )
     parametersFormLayout.addRow("Select file containing landmark names and coordinates to load:", self.inputFileSelector)
-    
+
     #
     # Get header length
     #
@@ -90,7 +90,7 @@ class ReadLandmarkFileWidget(ScriptedLoadableModuleWidget):
     # connections
     self.applyButton.connect('clicked(bool)', self.onApplyButton)
     self.inputFileSelector.connect('validInputChanged(bool)', self.onSelect)
-    
+
 
     # Add vertical spacer
     self.layout.addStretch(1)
@@ -216,7 +216,7 @@ class ReadLandmarkFileLogic(ScriptedLoadableModuleLogic):
         coordinates = [float(lineData[1]), float(lineData[2]), float(lineData[3])]
         name = lineData[0]
         fiducialNode.AddFiducialFromArray(coordinates, name)
-      else: 
+      else:
         logging.debug("Error: not a supported landmark file format")
 
     # Capture screenshot

--- a/ResampleCurves/ResampleCurves.py
+++ b/ResampleCurves/ResampleCurves.py
@@ -22,13 +22,13 @@ class ResampleCurves(ScriptedLoadableModule):
     self.parent.dependencies = []
     self.parent.contributors = ["Sara Rolfe (UW), Murat Maga (UW)"] # replace with "Firstname Lastname (Organization)"
     self.parent.helpText = """
-This module imports curve markups saved as FCSV files from a directory, resamples them at the requested sample rate and saves them to the output directory selected. 
+This module imports curve markups saved as FCSV files from a directory, resamples them at the requested sample rate and saves them to the output directory selected.
 """
     self.parent.helpText += self.getDefaultModuleDocumentationLink()
     self.parent.acknowledgementText = """
-This module was developed by Sara Rolfe and Murat Maga, through a NSF ABI Development grant, "An Integrated Platform for Retrieval, Visualization and Analysis of 
+This module was developed by Sara Rolfe and Murat Maga, through a NSF ABI Development grant, "An Integrated Platform for Retrieval, Visualization and Analysis of
 3D Morphology From Digital Biological Collections" (Award Numbers: 1759883 (Murat Maga), 1759637 (Adam Summers), 1759839 (Douglas Boyer)).
-https://nsf.gov/awardsearch/showAward?AWD_ID=1759883&HistoricalAwards=false 
+https://nsf.gov/awardsearch/showAward?AWD_ID=1759883&HistoricalAwards=false
 """ # replace with organization, grant and thanks.
 
 #
@@ -62,8 +62,8 @@ class ResampleCurvesWidget(ScriptedLoadableModuleWidget):
     self.inputDirectory.filters = ctk.ctkPathLineEdit.Dirs
     self.inputDirectory.setToolTip( "Select directory containing curves to resample" )
     parametersFormLayout.addRow("Input Directory:", self.inputDirectory)
-    
-    
+
+
     #
     # output directory selector
     #
@@ -97,7 +97,7 @@ class ResampleCurvesWidget(ScriptedLoadableModuleWidget):
     curveTypeSelector.addWidget(self.curveTypeClosed)
     curveTypeSelector.addStretch()
     parametersFormLayout.addRow("Curve Type: ",curveTypeSelector)
-    
+
     #
     # check box to trigger taking screen shots for later use in tutorials
     #
@@ -106,7 +106,7 @@ class ResampleCurvesWidget(ScriptedLoadableModuleWidget):
     self.enableScreenshotsFlagCheckBox.setToolTip("If checked, take screen shots for tutorials. Use Save Data to write them to disk.")
     parametersFormLayout.addRow("Enable Screenshots", self.enableScreenshotsFlagCheckBox)
 
-    
+
     #
     # Apply Button
     #
@@ -114,11 +114,11 @@ class ResampleCurvesWidget(ScriptedLoadableModuleWidget):
     self.applyButton.toolTip = "Run the conversion."
     self.applyButton.enabled = False
     parametersFormLayout.addRow(self.applyButton)
-    
+
     # connections
     self.applyButton.connect('clicked(bool)', self.onApplyButton)
     self.inputDirectory.connect('validInputChanged(bool)', self.onSelectInput)
- 
+
     # Add vertical spacer
     self.layout.addStretch(1)
 
@@ -130,7 +130,7 @@ class ResampleCurvesWidget(ScriptedLoadableModuleWidget):
     pass
 
   def onSelectInput(self):
-    self.applyButton.enabled = bool(self.inputDirectory.currentPath) 
+    self.applyButton.enabled = bool(self.inputDirectory.currentPath)
 
 
   def onApplyButton(self):
@@ -187,7 +187,7 @@ class ResampleCurvesLogic(ScriptedLoadableModuleLogic):
 
     annotationLogic = slicer.modules.annotations.logic()
     annotationLogic.CreateSnapShot(name, description, type, 1, imageData)
-    
+
   def ResamplePoints(self, originalPoints, sampledPoints, samplingDistance, closedCurve):
     if (not originalPoints or not sampledPoints or samplingDistance <= 0):
       print("ResamplePoints failed: invalid inputs")
@@ -208,7 +208,7 @@ class ResampleCurvesLogic(ScriptedLoadableModuleLogic):
       totalSegmentLength+=segmentLength
       if segmentLength <= 0:
         continue
-       
+
       remainingSegmentLength = distanceFromLastSampledPoint + segmentLength
       if round(remainingSegmentLength,4) >= round(samplingDistance,4):
         segmentDirectionVector = np.array([
@@ -233,8 +233,8 @@ class ResampleCurvesLogic(ScriptedLoadableModuleLogic):
         distanceFromLastSampledPoint += segmentLength
       previousCurvePoint = currentCurvePoint
 
-    return True  
-  
+    return True
+
   def run(self, inputDirectory, outputDirectory, resampleNumber, closedCurveOption):
     extension = ".fcsv"
     for file in os.listdir(inputDirectory):
@@ -242,17 +242,17 @@ class ResampleCurvesLogic(ScriptedLoadableModuleLogic):
         # read landmark file
         inputFilePath = os.path.join(inputDirectory, file)
         markupsNode =slicer.util.loadMarkupsFiducialList(inputFilePath)
-        
+
         #resample
         if closedCurveOption:
           curve = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLMarkupsClosedCurveNode", "resampled_temp")
           resampledCurve = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLMarkupsClosedCurveNode", "resampledClosedCurve")
-          
+
         else:
           curve = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLMarkupsCurveNode", "resampled_temp")
           resampledCurve = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLMarkupsCurveNode", "resampledCurve")
-          
-        
+
+
         vector=vtk.vtkVector3d()
         pt=[0,0,0]
         landmarkNumber = markupsNode.GetNumberOfFiducials()
@@ -266,14 +266,14 @@ class ResampleCurvesLogic(ScriptedLoadableModuleLogic):
 
         currentPoints = curve.GetCurvePointsWorld()
         newPoints = vtk.vtkPoints()
-        
+
         if closedCurveOption:
           sampleDist = curve.GetCurveLengthWorld()/(resampleNumber)
         else:
           sampleDist = curve.GetCurveLengthWorld()/(resampleNumber-1)
-        
+
         curve.ResamplePoints(currentPoints, newPoints,sampleDist,closedCurveOption)
-        
+
         #set resampleNumber control points
         if (newPoints.GetNumberOfPoints() == resampleNumber) or (closedCurveOption and (newPoints.GetNumberOfPoints() == resampleNumber+1)) :
           for controlPoint in range(0,resampleNumber):
@@ -282,9 +282,9 @@ class ResampleCurvesLogic(ScriptedLoadableModuleLogic):
             vector[1]=pt[1]
             vector[2]=pt[2]
             resampledCurve.AddControlPoint(vector)
-        
+
           newPointNumber = resampledCurve.GetNumberOfControlPoints()
-        
+
           # save
           newFileName = os.path.splitext(file)[0] + "_resample_" +str(newPointNumber) + extension
           outputFilePath = os.path.join(outputDirectory, newFileName)
@@ -295,7 +295,7 @@ class ResampleCurvesLogic(ScriptedLoadableModuleLogic):
         else:
           print("Error: resampling did not return expected number of points")
           print("Resampled Points: ", newPoints.GetNumberOfPoints())
-    
+
     logging.info('Processing completed')
 
     return True

--- a/SemiLandmark/Testing/SemiLandmarkBackup.py
+++ b/SemiLandmark/Testing/SemiLandmarkBackup.py
@@ -15,7 +15,7 @@ class SemiLandmark(ScriptedLoadableModule):
   """Uses ScriptedLoadableModule base class, available at:
     https://github.com/Slicer/Slicer/blob/master/Base/Python/slicer/ScriptedLoadableModule.py
     """
-  
+
   def __init__(self, parent):
     ScriptedLoadableModule.__init__(self, parent)
     self.parent.title = "SemiLandmark" # TODO make this more human readable by adding spaces
@@ -40,22 +40,22 @@ class SemiLandmarkWidget(ScriptedLoadableModuleWidget):
   """Uses ScriptedLoadableModuleWidget base class, available at:
     https://github.com/Slicer/Slicer/blob/master/Base/Python/slicer/ScriptedLoadableModule.py
     """
-  
+
   def setup(self):
     ScriptedLoadableModuleWidget.setup(self)
-    
+
     # Instantiate and connect widgets ...
-    
+
     #
     # Parameters Area
     #
     parametersCollapsibleButton = ctk.ctkCollapsibleButton()
     parametersCollapsibleButton.text = "Parameters"
     self.layout.addWidget(parametersCollapsibleButton)
-    
+
     # Layout within the dummy collapsible button
     parametersFormLayout = qt.QFormLayout(parametersCollapsibleButton)
-    
+
     #
     # input landmark directory selector
     #
@@ -73,32 +73,32 @@ class SemiLandmarkWidget(ScriptedLoadableModuleWidget):
     self.landmarkGridPoint1.singleStep = 1
     self.landmarkGridPoint1.setDecimals(0)
     self.landmarkGridPoint1.setToolTip("Input the landmark numbers to create grid")
-    
+
     self.landmarkGridPoint2 = ctk.ctkDoubleSpinBox()
     self.landmarkGridPoint2.minimum = 0
     self.landmarkGridPoint2.singleStep = 1
     self.landmarkGridPoint2.setDecimals(0)
     self.landmarkGridPoint2.setToolTip("Input the landmark numbers to create grid")
-    
+
     self.landmarkGridPoint3 = ctk.ctkDoubleSpinBox()
     self.landmarkGridPoint3.minimum = 0
     self.landmarkGridPoint3.singleStep = 1
     self.landmarkGridPoint3.setDecimals(0)
     self.landmarkGridPoint3.setToolTip("Input the landmark numbers to create grid")
-    
+
     self.landmarkGridPoint4 = ctk.ctkDoubleSpinBox()
     self.landmarkGridPoint4.minimum = 0
     self.landmarkGridPoint4.singleStep = 1
     self.landmarkGridPoint4.setDecimals(0)
     self.landmarkGridPoint4.setToolTip("Input the landmark numbers to create grid")
-    
+
     gridPointsLayout.addWidget(self.landmarkGridPoint1,1,2)
     gridPointsLayout.addWidget(self.landmarkGridPoint2,1,3)
     gridPointsLayout.addWidget(self.landmarkGridPoint3,1,4)
     gridPointsLayout.addWidget(self.landmarkGridPoint4,1,5)
-    
+
     parametersFormLayout.addRow("Semi-landmark grid points:", gridPointsLayout)
-    
+
     #
     # input mesh directory selector
     #
@@ -106,7 +106,7 @@ class SemiLandmarkWidget(ScriptedLoadableModuleWidget):
     self.inputMeshDirectory.directory = qt.QDir.homePath()
     parametersFormLayout.addRow("Mesh Directory:", self.inputMeshDirectory)
     self.inputMeshDirectory.setToolTip( "Select directory containing mesh files" )
-    
+
     #
     # output directory selector
     #
@@ -122,7 +122,7 @@ class SemiLandmarkWidget(ScriptedLoadableModuleWidget):
     self.enableScreenshotsFlagCheckBox.checked = 0
     self.enableScreenshotsFlagCheckBox.setToolTip("If checked, take screen shots for tutorials. Use Save Data to write them to disk.")
     parametersFormLayout.addRow("Enable Screenshots", self.enableScreenshotsFlagCheckBox)
-    
+
     #
     # Apply Button
     #
@@ -130,17 +130,17 @@ class SemiLandmarkWidget(ScriptedLoadableModuleWidget):
     self.applyButton.toolTip = "Run the conversion."
     self.applyButton.enabled = True
     parametersFormLayout.addRow(self.applyButton)
-    
+
     # connections
     self.applyButton.connect('clicked(bool)', self.onApplyButton)
-    
+
     # Add vertical spacer
     self.layout.addStretch(1)
-  
+
   def cleanup(self):
     pass
-  
-  
+
+
   def onApplyButton(self):
     logic = SemiLandmarkLogic()
     enableScreenshotsFlag = self.enableScreenshotsFlagCheckBox.checked
@@ -174,7 +174,7 @@ class SemiLandmarkLogic(ScriptedLoadableModuleLogic):
       #stickToSurface(newGridPoints(:,:,i), mesh)
     # save semi-landmarks
     #self.saveSemiLandmarks(newGridPoints, outputDirectory)
-    
+
     #Read data
     S=slicer.util.getNode("gor_skull")
     L=slicer.util.getNode("Gorilla_template_LM1")
@@ -232,7 +232,7 @@ class SemiLandmarkLogic(ScriptedLoadableModuleLogic):
     transform.SetBasisToR()
     transformNode=slicer.mrmlScene.AddNewNodeByClass("vtkMRMLTransformNode","TPS")
     transformNode.SetAndObserveTransformToParent(transform)
-  
+
     #Iterate through each triangle in fiducial mesh and project sampled triangle
     idList=vtk.vtkIdList()
     triangleArray = fiducialMesh.GetPolys()
@@ -241,7 +241,7 @@ class SemiLandmarkLogic(ScriptedLoadableModuleLogic):
     #define new landmark sets
     semilandmarkPoints=slicer.mrmlScene.AddNewNodeByClass("vtkMRMLMarkupsFiducialNode", "semiLM")
     gridPoints=slicer.mrmlScene.AddNewNodeByClass("vtkMRMLMarkupsFiducialNode", "grid")
-    
+
     print("Iterate through cells")
     #iterate through each triangle cell in the landmark mesh
     for triangle in range(4): #(triangleArray.GetNumberOfCells()):
@@ -254,19 +254,19 @@ class SemiLandmarkLogic(ScriptedLoadableModuleLogic):
         verticeID=idList.GetId(verticeIndex)
         verticeLocation=fiducialMesh.GetPoint(verticeID)
         targetPoints.InsertNextPoint(verticeLocation)
-        print("Adding target point: ", verticeLocation) 
-  
+        print("Adding target point: ", verticeLocation)
+
       transform.SetTargetLandmarks( targetPoints )
       model=slicer.mrmlScene.AddNewNodeByClass("vtkMRMLModelNode", "mesh_resampled")
       model.SetAndObservePolyData(gridPolydata)
       model.SetAndObserveTransformNodeID(transformNode.GetID())
       slicer.vtkSlicerTransformLogic().hardenTransform(model)
       transformedPolydata = model.GetPolyData()
-  
+
       # #get surface normal from each landmark point
       rayDirection=[0,0,0]
       normalArray = surfacePolydata.GetPointData().GetArray("Normals")
-      
+
       # #calculate average normal from cell landmarks
       for verticeIndex in range(3):
         verticeLocation = targetPoints.GetPoint(verticeIndex)
@@ -276,7 +276,7 @@ class SemiLandmarkLogic(ScriptedLoadableModuleLogic):
         rayDirection[0] += tempNormal[0]
         rayDirection[1] += tempNormal[1]
         rayDirection[2] += tempNormal[2]
-  
+
       for dim in range(len(rayDirection)):
         rayDirection[dim]=rayDirection[dim]/3
 
@@ -305,7 +305,7 @@ class SemiLandmarkLogic(ScriptedLoadableModuleLogic):
           projectionDistance=abs( (exteriorPoint[0] - modelPoint[0])+(exteriorPoint[1] - modelPoint[1])+ (exteriorPoint[2] - modelPoint[2]))
           semilandmarkPoints.AddFiducialFromArray(exteriorPoint)
         #if there are no intersections, reverse the normal vector
-        else: 
+        else:
           for dim in range(len(rayEndPoint)):
             rayEndPoint[dim] = modelPoint[dim] + rayDirection[dim]* -1000
           obbTree.IntersectWithLine(modelPoint,rayEndPoint,intersectionPoints,intersectionIds)
@@ -319,35 +319,35 @@ class SemiLandmarkLogic(ScriptedLoadableModuleLogic):
               closestPointId = pointLocator.FindClosestPoint(modelPoint)
               rayOrigin = surfacePolydata.GetPoint(closestPointId)
               semilandmarkPoints.AddFiducialFromArray(rayOrigin)
-  
+
           #if none in reverse direction, use closest mesh point
           else:
             closestPointId = pointLocator.FindClosestPoint(modelPoint)
             rayOrigin = surfacePolydata.GetPoint(closestPointId)
             semilandmarkPoints.AddFiducialFromArray(rayOrigin)
-      #remove temporary model node  
+      #remove temporary model node
       #slicer.mrmlScene.RemoveNode(model)
-  
+
     slicer.mrmlScene.RemoveNode(transformNode)
     return True
-  
+
   def getLandmarks(self, landmarkDirectory):
     files_to_open=[]
     for path, dir, files in os.walk(landmarkDirectory):
       for filename in files:
         if fnmatch.fnmatch(filename,"*.fcsv"):
           files_to_open.append(filename)
-    
+
     tmp = self.readLandmarkFile(os.path.join(landmarkDirectory, files_to_open[0]))    #check size of landmark data array
-    
+
     [i,j]=tmp.shape
     landmarkArray=np.zeros(shape=(i,j,len(files_to_open)))  # initialize landmark array
-    
-    for i in range(len(files_to_open)):      
+
+    for i in range(len(files_to_open)):
       tmp = self.readLandmarkFile(os.path.join(landmarkDirectory, files_to_open[i]))
-      landmarkArray[:,:,i]=tmp  
+      landmarkArray[:,:,i]=tmp
     return landmarkArray
-  
+
   def readLandmarkFile(self, landmarkFilename):
     datafile=open(landmarkFilename,'r')
     data=[]
@@ -364,15 +364,15 @@ class SemiLandmarkLogic(ScriptedLoadableModuleLogic):
       j=j+1
     slicer.app.processEvents()
     return dataArray
-  
+
   def getGridPoints(self, landmarkArray, gridLandmarkNumbers):
     gridArray=[]
     return gridArray
-  
+
   def takeScreenshot(self,name,description,type=-1):
     # show the message even if not taking a screen shot
     slicer.util.delayDisplay('Take screenshot: '+description+'.\nResult is available in the Annotations module.', 3000)
-    
+
     lm = slicer.app.layoutManager()
     # switch on the type to get the requested window
     widget = 0
@@ -396,12 +396,12 @@ class SemiLandmarkLogic(ScriptedLoadableModuleLogic):
       widget = slicer.util.mainWindow()
       # reset the type so that the node is set correctly
       type = slicer.qMRMLScreenShotDialog.FullLayout
-    
+
     # grab and convert to vtk image data
     qimage = ctk.ctkWidgetsUtils.grabWidget(widget)
     imageData = vtk.vtkImageData()
     slicer.qMRMLUtils().qImageToVtkImageData(qimage,imageData)
-    
+
     annotationLogic = slicer.modules.annotations.logic()
     annotationLogic.CreateSnapShot(name, description, type, 1, imageData)
 
@@ -412,18 +412,18 @@ class SemiLandmarkTest(ScriptedLoadableModuleTest):
     Uses ScriptedLoadableModuleTest base class, available at:
     https://github.com/Slicer/Slicer/blob/master/Base/Python/slicer/ScriptedLoadableModule.py
     """
-  
+
   def setUp(self):
     """ Do whatever is needed to reset the state - typically a scene clear will be enough.
       """
     slicer.mrmlScene.Clear(0)
-  
+
   def runTest(self):
     """Run as few or as many tests as needed here.
       """
     self.setUp()
     self.test_SemiLandmark1()
-  
+
   def test_SemiLandmark1(self):
     """ Ideally you should have several levels of tests.  At the lowest level
       tests should exercise the functionality of the logic with different inputs
@@ -435,7 +435,7 @@ class SemiLandmarkTest(ScriptedLoadableModuleTest):
       module.  For example, if a developer removes a feature that you depend on,
       your test should break so they know that the feature is needed.
       """
-    
+
     self.delayDisplay("Starting the test")
     #
     # first, get some data
@@ -453,7 +453,7 @@ class SemiLandmarkTest(ScriptedLoadableModuleTest):
         logging.info('Loading %s...' % (name,))
         loader(filePath)
     self.delayDisplay('Finished with download and loading')
-    
+
     volumeNode = slicer.util.getNode(pattern="FA")
     logic = SemiLandmarkLogic()
     self.assertIsNotNone( logic.hasImageData(volumeNode) )

--- a/SlicerMorphExtension.s4ext
+++ b/SlicerMorphExtension.s4ext
@@ -7,7 +7,7 @@
 # This is source code manager (i.e. svn)
 scm git
 scmurl https://github.com/SlicerMorph/SlicerMorph.git
-scmrevision master  
+scmrevision master
 
 # list dependencies
 # - These should be names of other modules that have .s4ext files
@@ -35,7 +35,7 @@ iconurl     https://github.com/SlicerMorph/SlicerMorph/blob/master/SlicerMorph_C
 status      Beta
 
 # One line stating what the module does
-description This toolkit enables retrieval, visualization, measurement and annotatation of high-resolution specimen data from volumetric scans (CTs and MRs) or 3D surface scans within 3D-Slicer. 
+description This toolkit enables retrieval, visualization, measurement and annotatation of high-resolution specimen data from volumetric scans (CTs and MRs) or 3D surface scans within 3D-Slicer.
 
 # Space separated list of urls
 screenshoturls https://na-mic.github.io/ProjectWeek/PW30_2019_GranCanaria/Projects/SlicerMorphGeometricMorphometricToolset/SM_screen.png https://na-mic.github.io/ProjectWeek/PW30_2019_GranCanaria/Projects/SlicerMorphGeometricMorphometricToolset/SM2.png

--- a/SlicerMorphSampleData/SlicerMorphSampleData.py
+++ b/SlicerMorphSampleData/SlicerMorphSampleData.py
@@ -21,11 +21,11 @@ class SlicerMorphSampleData(ScriptedLoadableModule):
     self.parent.contributors = ["Murat Maga & Sara Rolfe"]
     self.parent.helpText = """This module adds sample data for SlicerMorph into the SampleData module"""
     self.parent.acknowledgementText = """
-This work was was funded 
+This work was was funded
 """
 
     # don't show this module - additional data will be shown in SampleData module
-    parent.hidden = True 
+    parent.hidden = True
 
     # Add data sets to SampleData module
     iconsPath = os.path.join(os.path.dirname(self.parent.path), 'Resources/Icons')
@@ -48,7 +48,7 @@ This work was was funded
       nodeNames=['Gor_template_low_res', 'Gorilla_template_LM1'],
       thumbnailFileName=os.path.join(iconsPath, 'gorilla3D.png'),
       loadFileType=['ModelFile', 'MarkupsFiducials'],
-)  
+)
     SampleData.SampleDataLogic.registerCustomSampleDataSource(
       sampleName='Mouse Skull Landmarks Only',
       category='SlicerMorph',
@@ -67,7 +67,7 @@ This work was was funded
       nodeNames=['4074_skull', '4074_S_lm1'],
       thumbnailFileName=os.path.join(iconsPath, 'mouse3D.png'),
       loadFileType=['ModelFile','MarkupsFiducials'],
-)  
+)
     SampleData.SampleDataLogic.registerCustomSampleDataSource(
       sampleName='Bruker/Sykscan mCT Recon sample',
       category='SlicerMorph',

--- a/TransferSemiLandmarks/TransferSemiLandmarks.py
+++ b/TransferSemiLandmarks/TransferSemiLandmarks.py
@@ -19,7 +19,7 @@ class TransferSemiLandmarks(ScriptedLoadableModule):
   """Uses ScriptedLoadableModule base class, available at:
     https://github.com/Slicer/Slicer/blob/master/Base/Python/slicer/ScriptedLoadableModule.py
     """
-  
+
   def __init__(self, parent):
     ScriptedLoadableModule.__init__(self, parent)
     self.parent.title = "TransferSemiLandmarks" # TODO make this more human readable by adding spaces
@@ -27,7 +27,7 @@ class TransferSemiLandmarks(ScriptedLoadableModule):
     self.parent.dependencies = []
     self.parent.contributors = ["Sara Rolfe (UW), Murat Maga (UW)"] # replace with "Firstname Lastname (Organization)"
     self.parent.helpText = """
-      This module takes a directory of volumes and segments them using a user-supplied threshold value. The output segments are converted to models and saved in the 
+      This module takes a directory of volumes and segments them using a user-supplied threshold value. The output segments are converted to models and saved in the
       output directory.
       """
     self.parent.helpText += self.getDefaultModuleDocumentationLink()
@@ -47,19 +47,19 @@ class TransferSemiLandmarksWidget(ScriptedLoadableModuleWidget):
     """
   def onSelect(self):
     self.applyButton.enabled = bool (self.meshDirectory.currentPath and self.landmarkDirectory.currentPath and self.outputDirectory.currentPath)
-          
+
   def setup(self):
     ScriptedLoadableModuleWidget.setup(self)
-    
+
     # Instantiate and connect widgets ...
-    
+
     #
     # Parameters Area
     #
     parametersCollapsibleButton = ctk.ctkCollapsibleButton()
     parametersCollapsibleButton.text = "Parameters"
     self.layout.addWidget(parametersCollapsibleButton)
-    
+
     # Layout within the dummy collapsible button
     parametersFormLayout = qt.QFormLayout(parametersCollapsibleButton)
 
@@ -67,22 +67,22 @@ class TransferSemiLandmarksWidget(ScriptedLoadableModuleWidget):
     self.meshDirectory.filters = ctk.ctkPathLineEdit.Dirs
     self.meshDirectory.setToolTip( "Select directory containing landmarks" )
     parametersFormLayout.addRow("Mesh directory: ", self.meshDirectory)
-    
+
     self.landmarkDirectory=ctk.ctkPathLineEdit()
     self.landmarkDirectory.filters = ctk.ctkPathLineEdit.Dirs
     self.landmarkDirectory.setToolTip( "Select directory containing meshes" )
     parametersFormLayout.addRow("Landmark directory: ", self.landmarkDirectory)
-    
+
     self.gridFile=ctk.ctkPathLineEdit()
     self.gridFile.setToolTip( "Select file specifying semi-landmark connectivity" )
     parametersFormLayout.addRow("Grid connectivity file: ", self.gridFile)
-    
+
     # Select output directory
     self.outputDirectory=ctk.ctkPathLineEdit()
     self.outputDirectory.filters = ctk.ctkPathLineEdit.Dirs
     self.outputDirectory.setToolTip( "Select directory for output models: " )
     parametersFormLayout.addRow("Output directory: ", self.outputDirectory)
-    
+
     #
     # set sample rate value
     #
@@ -101,26 +101,26 @@ class TransferSemiLandmarksWidget(ScriptedLoadableModuleWidget):
     self.applyButton.toolTip = "Generate TransferSemiLandmarkss."
     self.applyButton.enabled = False
     parametersFormLayout.addRow(self.applyButton)
-    
+
     # connections
     self.meshDirectory.connect('validInputChanged(bool)', self.onSelect)
     self.landmarkDirectory.connect('validInputChanged(bool)', self.onSelect)
     self.gridFile.connect('validInputChanged(bool)', self.onSelect)
     self.outputDirectory.connect('validInputChanged(bool)', self.onSelect)
     self.applyButton.connect('clicked(bool)', self.onApplyButton)
-    
+
     # Add vertical spacer
     self.layout.addStretch(1)
-  
+
   def cleanup(self):
     pass
-  
-  
+
+
   def onApplyButton(self):
     logic = TransferSemiLandmarksLogic()
     logic.run(self.meshDirectory.currentPath, self.landmarkDirectory.currentPath, self.gridFile.currentPath,
       self.outputDirectory.currentPath, int(self.sampleRate.value))
-    
+
 #
 # TransferSemiLandmarksLogic
 #
@@ -142,7 +142,7 @@ class TransferSemiLandmarksLogic(ScriptedLoadableModuleLogic):
       next(gridReader) # skip header
       for row in gridReader:
         gridVertices.append([int(row[0]),int(row[1]),int(row[2])])
-    
+
     for meshFileName in os.listdir(meshDirectory):
       if(not meshFileName.startswith(".")):
         print (meshFileName)
@@ -157,7 +157,7 @@ class TransferSemiLandmarksLogic(ScriptedLoadableModuleLogic):
             landmarkNode = slicer.util.loadMarkupsFiducialList(lmFilePath)
             landmarkNumber=landmarkNode.GetNumberOfControlPoints()
             for n in range(landmarkNumber):
-              landmarkNode.SetNthControlPointLabel(n, str(n+1)) 
+              landmarkNode.SetNthControlPointLabel(n, str(n+1))
             for triangle in gridVertices:
               newNode = SLLogic.run(meshNode, landmarkNode, triangle, sampleRate)
             nodeList = slicer.mrmlScene.GetNodesByClass("vtkMRMLMarkupsFiducialNode")
@@ -167,14 +167,14 @@ class TransferSemiLandmarksLogic(ScriptedLoadableModuleLogic):
             if not success:
               print("Something went wrong in SemilandmarkLogic.merge")
             outputFileName = meshFileName + '_merged.fcsv'
-            outputFilePath = os.path.join(ouputDirectory, outputFileName) 
+            outputFilePath = os.path.join(ouputDirectory, outputFileName)
             slicer.util.saveNode(mergedLandmarkNode, outputFilePath)
             slicer.mrmlScene.Clear(0)
-          
+
   def takeScreenshot(self,name,description,type=-1):
     # show the message even if not taking a screen shot
     slicer.util.delayDisplay('Take screenshot: '+description+'.\nResult is available in the Annotations module.', 3000)
-    
+
     lm = slicer.app.layoutManager()
     # switch on the type to get the requested window
     widget = 0
@@ -198,12 +198,12 @@ class TransferSemiLandmarksLogic(ScriptedLoadableModuleLogic):
       widget = slicer.util.mainWindow()
       # reset the type so that the node is set correctly
       type = slicer.qMRMLScreenShotDialog.FullLayout
-    
+
     # grab and convert to vtk image data
     qimage = ctk.ctkWidgetsUtils.grabWidget(widget)
     imageData = vtk.vtkImageData()
     slicer.qMRMLUtils().qImageToVtkImageData(qimage,imageData)
-    
+
     annotationLogic = slicer.modules.annotations.logic()
     annotationLogic.CreateSnapShot(name, description, type, 1, imageData)
 
@@ -214,18 +214,18 @@ class TransferSemiLandmarksTest(ScriptedLoadableModuleTest):
     Uses ScriptedLoadableModuleTest base class, available at:
     https://github.com/Slicer/Slicer/blob/master/Base/Python/slicer/ScriptedLoadableModule.py
     """
-  
+
   def setUp(self):
     """ Do whatever is needed to reset the state - typically a scene clear will be enough.
       """
     slicer.mrmlScene.Clear(0)
-  
+
   def runTest(self):
     """Run as few or as many tests as needed here.
       """
     self.setUp()
     self.test_TransferSemiLandmarks1()
-  
+
   def test_TransferSemiLandmarks1(self):
     """ Ideally you should have several levels of tests.  At the lowest level
       tests should exercise the functionality of the logic with different inputs
@@ -237,7 +237,7 @@ class TransferSemiLandmarksTest(ScriptedLoadableModuleTest):
       module.  For example, if a developer removes a feature that you depend on,
       your test should break so they know that the feature is needed.
       """
-    
+
     self.delayDisplay("Starting the test")
     #
     # first, get some data
@@ -255,7 +255,7 @@ class TransferSemiLandmarksTest(ScriptedLoadableModuleTest):
         logging.info('Loading %s...' % (name,))
         loader(filePath)
     self.delayDisplay('Finished with download and loading')
-    
+
     volumeNode = slicer.util.getNode(pattern="FA")
     logic = TransferSemiLandmarksLogic()
     self.assertIsNotNone( logic.hasImageData(volumeNode) )

--- a/VolumeToMesh/VolumeToMesh.py
+++ b/VolumeToMesh/VolumeToMesh.py
@@ -16,7 +16,7 @@ class VolumeToMesh(ScriptedLoadableModule):
   """Uses ScriptedLoadableModule base class, available at:
     https://github.com/Slicer/Slicer/blob/master/Base/Python/slicer/ScriptedLoadableModule.py
     """
-  
+
   def __init__(self, parent):
     ScriptedLoadableModule.__init__(self, parent)
     self.parent.title = "VolumeToMesh" # TODO make this more human readable by adding spaces
@@ -24,7 +24,7 @@ class VolumeToMesh(ScriptedLoadableModule):
     self.parent.dependencies = []
     self.parent.contributors = ["Sara Rolfe (UW), Murat Maga (UW)"] # replace with "Firstname Lastname (Organization)"
     self.parent.helpText = """
-      This module takes a directory of volumes and segments them using a user-supplied threshold value. The output segments are converted to models and saved in the 
+      This module takes a directory of volumes and segments them using a user-supplied threshold value. The output segments are converted to models and saved in the
       output directory.
       """
     self.parent.helpText += self.getDefaultModuleDocumentationLink()
@@ -44,25 +44,25 @@ class VolumeToMeshWidget(ScriptedLoadableModuleWidget):
     """
   def onSelectInput(self):
     self.applyButton.enabled = bool (self.inputDirectory.currentPath and self.outputDirectory.currentPath)
-  
+
   def onSelectOutput(self):
     self.applyButton.enabled = bool (self.inputDirectory.currentPath and self.outputDirectory.currentPath)
-        
+
   def setup(self):
     ScriptedLoadableModuleWidget.setup(self)
-    
+
     # Instantiate and connect widgets ...
-    
+
     #
     # Parameters Area
     #
     parametersCollapsibleButton = ctk.ctkCollapsibleButton()
     parametersCollapsibleButton.text = "Parameters"
     self.layout.addWidget(parametersCollapsibleButton)
-    
+
     # Layout within the dummy collapsible button
     parametersFormLayout = qt.QFormLayout(parametersCollapsibleButton)
-    
+
     self.inputDirectory=ctk.ctkPathLineEdit()
     self.inputDirectory.filters = ctk.ctkPathLineEdit.Dirs
     self.inputDirectory.setToolTip( "Select directory containing volumes" )
@@ -80,7 +80,7 @@ class VolumeToMeshWidget(ScriptedLoadableModuleWidget):
     self.extensionOptionGZ = qt.QRadioButton(".nii.gz")
     self.extensionOptionGZ.setChecked(True)
     parametersFormLayout.addRow("Select extension type: ", self.extensionOptionGZ)
-    
+
     #
     # set threshold value
     #
@@ -99,7 +99,7 @@ class VolumeToMeshWidget(ScriptedLoadableModuleWidget):
     self.applyButton.toolTip = "Generate VolumeToMeshs."
     self.applyButton.enabled = False
     parametersFormLayout.addRow(self.applyButton)
-    
+
     #
     # check box to trigger taking screen shots for later use in tutorials
     #
@@ -107,30 +107,30 @@ class VolumeToMeshWidget(ScriptedLoadableModuleWidget):
     self.enableScreenshotsFlagCheckBox.checked = 0
     self.enableScreenshotsFlagCheckBox.setToolTip("If checked, take screen shots for tutorials. Use Save Data to write them to disk.")
     parametersFormLayout.addRow("Enable Screenshots", self.enableScreenshotsFlagCheckBox)
-    
 
-    
+
+
     # connections
     self.inputDirectory.connect('validInputChanged(bool)', self.onSelectInput)
     self.outputDirectory.connect('validInputChanged(bool)', self.onSelectOutput)
     self.applyButton.connect('clicked(bool)', self.onApplyButton)
-    
+
     # Add vertical spacer
     self.layout.addStretch(1)
-  
+
   def cleanup(self):
     pass
-  
-  
+
+
   def onApplyButton(self):
     logic = VolumeToMeshLogic()
     enableScreenshotsFlag = self.enableScreenshotsFlagCheckBox.checked
     extension =""
     if self.extensionOptionGZ.checked:
       extension = ".nii.gz"
-    
+
     logic.run(self.inputDirectory.currentPath, self.outputDirectory.currentPath, extension, int(self.threshold.value))
-    
+
 #
 # VolumeToMeshLogic
 #
@@ -172,17 +172,17 @@ class VolumeToMeshLogic(ScriptedLoadableModuleLogic):
         modelNode.CreateDefaultDisplayNodes()
         modelNode.SetAndObservePolyData(polydataFlip)
         outputFilename = os.path.join(outputDirectory, imageName + '.vtk')
-        slicer.util.saveNode(modelNode, outputFilename) 
+        slicer.util.saveNode(modelNode, outputFilename)
         slicer.mrmlScene.RemoveNode(labelVolumeNode)
         slicer.mrmlScene.RemoveNode(volumeNode)
         slicer.mrmlScene.RemoveNode(segmentationNode)
-        slicer.mrmlScene.RemoveNode(modelNode)    
-  
+        slicer.mrmlScene.RemoveNode(modelNode)
+
 
   def takeScreenshot(self,name,description,type=-1):
     # show the message even if not taking a screen shot
     slicer.util.delayDisplay('Take screenshot: '+description+'.\nResult is available in the Annotations module.', 3000)
-    
+
     lm = slicer.app.layoutManager()
     # switch on the type to get the requested window
     widget = 0
@@ -206,12 +206,12 @@ class VolumeToMeshLogic(ScriptedLoadableModuleLogic):
       widget = slicer.util.mainWindow()
       # reset the type so that the node is set correctly
       type = slicer.qMRMLScreenShotDialog.FullLayout
-    
+
     # grab and convert to vtk image data
     qimage = ctk.ctkWidgetsUtils.grabWidget(widget)
     imageData = vtk.vtkImageData()
     slicer.qMRMLUtils().qImageToVtkImageData(qimage,imageData)
-    
+
     annotationLogic = slicer.modules.annotations.logic()
     annotationLogic.CreateSnapShot(name, description, type, 1, imageData)
 
@@ -222,18 +222,18 @@ class VolumeToMeshTest(ScriptedLoadableModuleTest):
     Uses ScriptedLoadableModuleTest base class, available at:
     https://github.com/Slicer/Slicer/blob/master/Base/Python/slicer/ScriptedLoadableModule.py
     """
-  
+
   def setUp(self):
     """ Do whatever is needed to reset the state - typically a scene clear will be enough.
       """
     slicer.mrmlScene.Clear(0)
-  
+
   def runTest(self):
     """Run as few or as many tests as needed here.
       """
     self.setUp()
     self.test_VolumeToMesh1()
-  
+
   def test_VolumeToMesh1(self):
     """ Ideally you should have several levels of tests.  At the lowest level
       tests should exercise the functionality of the logic with different inputs
@@ -245,7 +245,7 @@ class VolumeToMeshTest(ScriptedLoadableModuleTest):
       module.  For example, if a developer removes a feature that you depend on,
       your test should break so they know that the feature is needed.
       """
-    
+
     self.delayDisplay("Starting the test")
     #
     # first, get some data
@@ -263,7 +263,7 @@ class VolumeToMeshTest(ScriptedLoadableModuleTest):
         logging.info('Loading %s...' % (name,))
         loader(filePath)
     self.delayDisplay('Finished with download and loading')
-    
+
     volumeNode = slicer.util.getNode(pattern="FA")
     logic = VolumeToMeshLogic()
     self.assertIsNotNone( logic.hasImageData(volumeNode) )


### PR DESCRIPTION
This PR trims trailing whitespace for all files. This is motivated after work in #23 where my changes were including a lot of whitespace diff changes because I have the common setting "Trim Trailling Whitespace" enabled in my IDE which automatically happens on save. I turned this setting off temporarily to issue that commit so not to include a bunch of line changes due to whitespace changes.

Trimming trailing whitespace helps prevent unnecessary line diffs due to changes in whitespace making it harder to read the actual non-whitespace changes.