### PR TITLE
ENH: Remove extension controlled install of Scipy

### DIFF
--- a/Auto3dgm/Auto3dgm.py
+++ b/Auto3dgm/Auto3dgm.py
@@ -45,11 +45,6 @@ and Steve Pieper, Isomics, Inc. and was partially funded by NIH grant 3P41RR0132
   def checkPythonPackages(self):
     print('Checking for required python packages')
     try:
-      import scipy
-    except:
-      slicer.util.pip_install('scipy')
-      import scipy
-    try:
       import mosek
     except:
       slicer.util.pip_install('mosek')


### PR DESCRIPTION
Scipy was added as a default Slicer python package in https://github.com/Slicer/Slicer/commit/47deb76d7556e40de4e25e585c4b24a63a153da5.