### PR TITLE
Adds fcsv as a save option for any markup type

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,6 +36,7 @@ add_subdirectory(TransferSemiLandmarksWarp)
 add_subdirectory(VolumeToMesh)
 add_subdirectory(SegmentEndocranium)
 add_subdirectory(ExportAs)
+add_subdirectory(MarkupsFcsv)
 ## NEXT_MODULE
 
 #-----------------------------------------------------------------------------

--- a/MarkupsFcsv/CMakeLists.txt
+++ b/MarkupsFcsv/CMakeLists.txt
@@ -1,0 +1,18 @@
+#-----------------------------------------------------------------------------
+set(MODULE_NAME MarkupsFcsv)
+
+#-----------------------------------------------------------------------------
+set(MODULE_PYTHON_SCRIPTS
+  ${MODULE_NAME}.py
+  )
+
+set(MODULE_PYTHON_RESOURCES
+  )
+
+#-----------------------------------------------------------------------------
+slicerMacroBuildScriptedModule(
+  NAME ${MODULE_NAME}
+  SCRIPTS ${MODULE_PYTHON_SCRIPTS}
+  RESOURCES ${MODULE_PYTHON_RESOURCES}
+  WITH_GENERIC_TESTS
+  )

--- a/MarkupsFcsv/MarkupsFcsv.py
+++ b/MarkupsFcsv/MarkupsFcsv.py
@@ -1,0 +1,59 @@
+import logging
+import slicer
+
+class MarkupsFcsv:
+  def __init__(self, parent):
+    parent.title = "Markups Fcsv File Writer"
+    parent.categories = ["Utilities"]
+    parent.dependencies = []
+    parent.contributors = ["Steve Pieper, Isomics, Inc."]
+    parent.helpText = """This is a file writer to allow Markups control points in Fcsv format"""
+    parent.acknowledgementText = """
+This module was developed by Steve Pieper through a NSF ABI Development grant, "An Integrated Platform for Retrieval, Visualization and Analysis of
+3D Morphology From Digital Biological Collections" (Award Numbers: 1759883 (Murat Maga), 1759637 (Adam Summers), 1759839 (Douglas Boyer)).
+https://nsf.gov/awardsearch/showAward?AWD_ID=1759883&HistoricalAwards=false
+""" # replace with organization, grant and thanks.
+    parent.hidden = True
+    self.parent = parent
+
+
+class MarkupsFcsvFileWriter:
+    def __init__(self, parent):
+        self.parent = parent
+
+    def description(self):
+        return 'Markup points as fcsv'
+
+    def fileType(self):
+        return 'MarkupsFile'
+
+    def canWriteObject(self, obj):
+        return isinstance(obj, slicer.vtkMRMLMarkupsNode)
+
+    def extensions(self, obj):
+        return ['Fiducial csv (*.fcsv)']
+
+    def write(self, properties):
+        print("parent", self.parent)
+        print("Write", properties)
+
+        if (not "nodeID" in properties 
+                or not "fileName" in properties):
+            logging.error("Bad properties passed to MarkupsFcsvFileWriter.write")
+            return False
+        markupNode = slicer.mrmlScene.GetNodeByID(properties["nodeID"])
+        if not markupNode or not self.canWriteObject(markupNode):
+            logging.error("Bad MarkupNode passed to MarkupsFcsvFileWriter.write")
+            return False
+        storageNode = slicer.vtkMRMLMarkupsFiducialStorageNode()
+        slicer.mrmlScene.AddNode(storageNode)
+        fileName = properties["fileName"]
+        if fileName.endswith(".fcsv.fcsv"):
+            fileName = fileName[:-5]
+        properties["fileName"] = fileName
+        storageNode.SetFileName(fileName)
+        storageNode.SetURI(None)
+        result = storageNode.WriteData(markupNode)
+        if result:
+            self.parent.writtenNodes = [markupNode.GetID()]
+        return bool(result)


### PR DESCRIPTION
This makes it appear in the Export As context menu
and in the Save Data dialog.

As discussed with the SlicerMorph team, when used in the
Export As context menu it will not set the default
storage node, so that .mrk.json will be the default when
saving a scene or mrb.

Proper operation in the Save Data dialog depends on this
change to the Slicer core:
https://github.com/Slicer/Slicer/pull/5025