### PR TITLE
Add names to subject hierarchy plugins

### DIFF
--- a/ExportAs/ExportAs.py
+++ b/ExportAs/ExportAs.py
@@ -22,6 +22,7 @@ class ExportAs(ScriptedLoadableModule):
             import SubjectHierarchyPlugins
             from ExportAs import ExportAsSubjectHierarchyPlugin
             scriptedPlugin = slicer.qSlicerSubjectHierarchyScriptedPlugin(None)
+            scriptedPlugin.name = "ExportAs"
             scriptedPlugin.setPythonSource(ExportAsSubjectHierarchyPlugin.filePath)
         slicer.app.connect("startupCompleted()", onStartupCompleted)
 

--- a/MarkupEditor/MarkupEditor.py
+++ b/MarkupEditor/MarkupEditor.py
@@ -46,6 +46,8 @@ and was partially funded by NIH grant 3P41RR013218-12S1.
         import SubjectHierarchyPlugins
         from MarkupEditor import MarkupEditorSubjectHierarchyPlugin
         scriptedPlugin = slicer.qSlicerSubjectHierarchyScriptedPlugin(None)
+        scriptedPlugin.name = "MarkupEditor"
+
         scriptedPlugin.setPythonSource(MarkupEditorSubjectHierarchyPlugin.filePath)
         pluginHandler = slicer.qSlicerSubjectHierarchyPluginHandler.instance()
         pluginHandler.registerPlugin(scriptedPlugin)


### PR DESCRIPTION
This avoids clashes when both plugins are used
together, as in the packaged SlicerMorph

@muratmaga this should fix the context menu issue we looked at yesterday.  It's a small change.  I'll go ahead and merge and then you can test tomorrow or sometime.