### PR TITLE
Remove ResampleCurveWorld call

### DIFF
--- a/MarkupEditor/MarkupEditor.py
+++ b/MarkupEditor/MarkupEditor.py
@@ -287,8 +287,6 @@ class MarkupEditorLogic(ScriptedLoadableModuleLogic):
       row = (1 - (y + 1)/2) * threeDWidget.height
       return column, row
 
-    curveNode.ResampleCurveWorld(5)
-
     selectionPolygon = qt.QPolygonF()
     for index in range(curveNode.GetNumberOfControlPoints()):
       ras = [0]*3
@@ -334,7 +332,7 @@ class MarkupEditorLogic(ScriptedLoadableModuleLogic):
             if picked:
               fiducialsNode.SetNthControlPointSelected(index, False)
           else:
-            print(f"Unknown selectOption {selectOption}")
+            logging.error(f"Unknown selectOption {selectOption}")
 
 
 #


### PR DESCRIPTION
This was used to ensure a smooth sampling
of the curve node, but is not needed since
we are now using linear edges only.

Plus this led to error conditions for
very small fiducial sets (like features
on a small mammal tooth).

If ever re-enabled it should be made
adaptive to the data size somehow.