### PR TITLE
Extra morph prefs

### DIFF
--- a/MorphPreferences/MorphPreferences.py
+++ b/MorphPreferences/MorphPreferences.py
@@ -83,11 +83,38 @@ class _ui_MorphPreferencesSettingsPanel(object):
     loadNowButton.connect("clicked()", lambda rcPath=rcPath: MorphPreferences.loadRCFile(rcPath))
     self.loadMorphPreferencesCheckBox.connect("toggled(bool)", self.onLoadMorphPreferencesCheckBoxToggled)
 
+    hbox = qt.QHBoxLayout()
+    self.downloadDirectory = qt.QLineEdit()
+    self.downloadDirectory.readOnly = True
+    key = "MorphPreferences/downloadDirectory"
+    downloadDirectory = slicer.util.settingsValue(key, "", converter=str)
+    if downloadDirectory == "":
+        self.downloadDirectory.setText("Defaults")
+    else:
+        self.downloadDirectory.setText(downloadDirectory)
+        self.setDownloadDirectories(downloadDirectory)
+    self.setDownloadDirectoryButton = qt.QPushButton("Set")
+    self.setDownloadDirectoryButton.connect("clicked()", self.onSetDownloadDirectory)
+    hbox.addWidget(self.downloadDirectory)
+    hbox.addWidget(self.setDownloadDirectoryButton)
+    genericGroupBoxFormLayout.addRow("Download directory:", hbox)
+
     vBoxLayout.addWidget(genericGroupBox)
     vBoxLayout.addStretch(1)
 
   def onLoadMorphPreferencesCheckBoxToggled(self, checked):
-    qt.QSettings().setValue("MorphPreferences/customize", checked)
+    slicer.app.settings().setValue("MorphPreferences/customize", checked)
+
+  def onSetDownloadDirectory(self):
+    directory = qt.QFileDialog.getExistingDirectory()
+    if directory != "":
+        self.downloadDirectory.setText(directory)
+        slicer.app.settings().setValue("MorphPreferences/downloadDirectory", directory)
+        self.setDownloadDirectories(directory)
+
+  def setDownloadDirectories(self, directory):
+    slicer.app.settings().setValue("Cache/Path", directory)
+    slicer.app.settings().setValue("Modules/TemporaryDirectory", directory)
 
 
 class MorphPreferencesSettingsPanel(ctk.ctkSettingsPanel):

--- a/MorphPreferences/MorphPreferences.py
+++ b/MorphPreferences/MorphPreferences.py
@@ -69,13 +69,16 @@ class _ui_MorphPreferencesSettingsPanel(object):
     self.loadMorphPreferencesCheckBox.checked = customize
     genericGroupBoxFormLayout.addRow("Use SlicerMorph customizations:", self.loadMorphPreferencesCheckBox)
 
+    hbox = qt.QHBoxLayout()
     label = qt.QLineEdit(rcPath)
     label.readOnly = True
     genericGroupBoxFormLayout.addRow("Customization file:", label)
 
     loadNowButton = qt.QPushButton("Load now")
     loadNowButton.toolTip = "Load the customization file now"
-    genericGroupBoxFormLayout.addRow("Customization file:", loadNowButton)
+    hbox.addWidget(label)
+    hbox.addWidget(loadNowButton)
+    genericGroupBoxFormLayout.addRow("Customization file:", hbox)
 
     loadNowButton.connect("clicked()", lambda rcPath=rcPath: MorphPreferences.loadRCFile(rcPath))
     self.loadMorphPreferencesCheckBox.connect("toggled(bool)", self.onLoadMorphPreferencesCheckBoxToggled)

--- a/MorphPreferences/MorphPreferences.py
+++ b/MorphPreferences/MorphPreferences.py
@@ -22,7 +22,7 @@ class MorphPreferences(ScriptedLoadableModule):
         def onStartupCompleted():
             toBool = slicer.util.toBool
             key = "MorphPreferences/customize"
-            customize = slicer.util.settingsValue(key, True, converter=toBool)
+            customize = slicer.util.settingsValue(key, False, converter=toBool)
             if customize:
                 MorphPreferences.loadRCFile(self.rcPath())
 

--- a/MorphPreferences/MorphPreferences.py
+++ b/MorphPreferences/MorphPreferences.py
@@ -69,7 +69,8 @@ class _ui_MorphPreferencesSettingsPanel(object):
     self.loadMorphPreferencesCheckBox.checked = customize
     genericGroupBoxFormLayout.addRow("Use SlicerMorph customizations:", self.loadMorphPreferencesCheckBox)
 
-    label = qt.QLabel(rcPath)
+    label = qt.QLineEdit(rcPath)
+    label.readOnly = True
     genericGroupBoxFormLayout.addRow("Customization file:", label)
 
     loadNowButton = qt.QPushButton("Load now")

--- a/MorphPreferences/Resources/SlicerMorphRC.py
+++ b/MorphPreferences/Resources/SlicerMorphRC.py
@@ -34,6 +34,12 @@ slicer.util.findChild(slicer.util.mainWindow(), 'LogoLabel').visible = False
 #collapse Data Probe tab by default to save space modules tab
 slicer.util.findChild(slicer.util.mainWindow(), name='DataProbeCollapsibleWidget').collapsed = True
 
+# set volume rendering modes
+#
+settings = qt.QSettings()
+settings.setValue("VolumeRendering/RenderingMethod", "vtkMRMLGPURayCastVolumeRenderingDisplayNode")
+settings.setValue("VolumeRendering/DefaultQuality", "Normal")
+
 #
 # Keyboard shortcuts
 #

--- a/MorphPreferences/Resources/SlicerMorphRC.py
+++ b/MorphPreferences/Resources/SlicerMorphRC.py
@@ -161,3 +161,4 @@ for (shortcutKey, callback) in shortcuts:
 logging.info(f"  {len(shortcuts)} keyboard shortcuts installed")
 
 logging.info("Done customizing with SlicerMorphRC.py")
+logging.info("On first load of customization, restart Slicer to take effect.")

--- a/MorphPreferences/Resources/SlicerMorphRC.py
+++ b/MorphPreferences/Resources/SlicerMorphRC.py
@@ -54,6 +54,14 @@ settings.setValue("VolumeRendering/RenderingMethod", "vtkMRMLGPURayCastVolumeRen
 settings.setValue("VolumeRendering/DefaultQuality", "Normal")
 
 #
+# orthographic view mode and turn on rulers
+#
+settings = slicer.app.settings()
+settings.setValue("Default3DView/UseOrthographicProjection", True)
+settings.setValue("Default3DView/RulerType", "thin")
+settings.setValue("DefaultSliceView/RulerType", "thin")
+
+#
 # Keyboard shortcuts
 #
 

--- a/MorphPreferences/Resources/SlicerMorphRC.py
+++ b/MorphPreferences/Resources/SlicerMorphRC.py
@@ -62,6 +62,12 @@ settings.setValue("Default3DView/RulerType", "thin")
 settings.setValue("DefaultSliceView/RulerType", "thin")
 
 #
+# units settings
+#
+revisionUserSettings = slicer.app.revisionUserSettings()
+revisionUserSettings.setValue("length/precision", 10)
+
+#
 # Keyboard shortcuts
 #
 

--- a/MorphPreferences/Resources/SlicerMorphRC.py
+++ b/MorphPreferences/Resources/SlicerMorphRC.py
@@ -3,37 +3,50 @@ import logging
 logging.info("Customizing with SlicerMorphRC.py")
 
 
+#
 #set the default volume storage to not compress by default
+#
 defaultVolumeStorageNode = slicer.vtkMRMLVolumeArchetypeStorageNode()
 defaultVolumeStorageNode.SetUseCompression(0)
 slicer.mrmlScene.AddDefaultNode(defaultVolumeStorageNode)
 logging.info("  Volume nodes will be stored uncompressed by default")
 
+#
 #set the default volume storage to not compress by default
+#
 defaultVolumeStorageNode = slicer.vtkMRMLSegmentationStorageNode()
 defaultVolumeStorageNode.SetUseCompression(0)
 slicer.mrmlScene.AddDefaultNode(defaultVolumeStorageNode)
 logging.info("  Segmentation nodes will be stored uncompressed")
 
+#
 #set the default model save format to ply (from vtk)
+#
 defaultModelStorageNode = slicer.vtkMRMLModelStorageNode()
 defaultModelStorageNode.SetUseCompression(0)
 defaultModelStorageNode.SetDefaultWriteFileExtension('ply')
 slicer.mrmlScene.AddDefaultNode(defaultModelStorageNode)
 
+#
 #disable interpolation of the volumes by default
+#
 def NoInterpolate(caller,event):
   for node in slicer.util.getNodes('*').values():
     if node.IsA('vtkMRMLScalarVolumeDisplayNode'):
       node.SetInterpolate(0)
 slicer.mrmlScene.AddObserver(slicer.mrmlScene.NodeAddedEvent, NoInterpolate)
 
+#
 #hide SLicer logo in module tab
+#
 slicer.util.findChild(slicer.util.mainWindow(), 'LogoLabel').visible = False
 
+#
 #collapse Data Probe tab by default to save space modules tab
+#
 slicer.util.findChild(slicer.util.mainWindow(), name='DataProbeCollapsibleWidget').collapsed = True
 
+#
 # set volume rendering modes
 #
 settings = qt.QSettings()

--- a/MorphPreferences/Resources/SlicerMorphRC.py
+++ b/MorphPreferences/Resources/SlicerMorphRC.py
@@ -49,7 +49,7 @@ slicer.util.findChild(slicer.util.mainWindow(), name='DataProbeCollapsibleWidget
 #
 # set volume rendering modes
 #
-settings = qt.QSettings()
+settings = slicer.app.settings()
 settings.setValue("VolumeRendering/RenderingMethod", "vtkMRMLGPURayCastVolumeRenderingDisplayNode")
 settings.setValue("VolumeRendering/DefaultQuality", "Normal")
 


### PR DESCRIPTION
A bunch of things to match the write up in the SlicerMorph paper and other requests.

Note that some of these settings are "sticky" so they won't be reset by disabling
the SicerMorphRC.py (users will need to unset them by hand, or delete
settings to restore defaults).