### PR TITLE
Allow fiducial placement on any threeD view

### DIFF
--- a/MorphPreferences/Resources/SlicerMorphRC.py
+++ b/MorphPreferences/Resources/SlicerMorphRC.py
@@ -124,21 +124,15 @@ def setLayoutFourUpView():
 def placeFiducial():
     interactionNode = slicer.mrmlScene.GetNodeByID("vtkMRMLInteractionNodeSingleton")
     interactionNode.SetCurrentInteractionMode(interactionNode.Place)
-    view = slicer.app.layoutManager().threeDWidget(0).threeDView()
-    style = view.interactorStyle()
-    interactor = style.GetInteractor()
-    mousePosition = view.mapFromGlobal(qt.QCursor.pos())
-    point = (mousePosition.x(), view.height - mousePosition.y())
-
+    cursorPosition = qt.QCursor.pos()
+    widget = slicer.app.widgetAt(cursorPosition)
+    mousePosition = widget.mapFromGlobal(cursorPosition)
+    interactor = widget.parent().interactor()
+    point = (mousePosition.x(), widget.height - mousePosition.y())
     interactor.SetEventPosition(*point)
     interactor.MouseMoveEvent()
     interactor.LeftButtonPressEvent()
     interactor.LeftButtonReleaseEvent()
-
-    # TODO: currently we use the first threeDWidget because widgetAt
-    # returns a ctk class that does not expose the vtk interactor
-    mousePosition = qt.QCursor.pos()
-    widget = slicer.app.widgetAt(mousePosition)
 
 def togglePlaceModePersistence():
     interactionNode = slicer.mrmlScene.GetNodeByID("vtkMRMLInteractionNodeSingleton")


### PR DESCRIPTION
Uses the parent class of the selected QWidget to
access the vtk interactor class.

Co-authored-by: Andras Lasso <lasso@queensu.ca>