### PR TITLE
Add cropped volume import to ImageStacks

### DIFF
--- a/ImageStacks/ImageStacks.py
+++ b/ImageStacks/ImageStacks.py
@@ -5,6 +5,7 @@ import numpy
 import vtk, qt, ctk, slicer
 import SimpleITK as sitk
 from slicer.ScriptedLoadableModule import *
+from slicer.util import VTKObservationMixin
 import logging
 
 #
@@ -53,14 +54,17 @@ https://nsf.gov/awardsearch/showAward?AWD_ID=1759883&HistoricalAwards=false
 # ImageStacksWidget
 #
 
-class ImageStacksWidget(ScriptedLoadableModuleWidget):
+class ImageStacksWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
   """Uses ScriptedLoadableModuleWidget base class, available at:
   https://github.com/Slicer/Slicer/blob/master/Base/Python/slicer/ScriptedLoadableModule.py
   """
 
   def __init__(self, parent):
     ScriptedLoadableModuleWidget.__init__(self,parent)
+    VTKObservationMixin.__init__(self)
+
     self.logic = ImageStacksLogic()
+    self.outputROINode = None  # observed ROI node
 
   def setup(self):
     ScriptedLoadableModuleWidget.setup(self)
@@ -80,48 +84,49 @@ class ImageStacksWidget(ScriptedLoadableModuleWidget):
 
     # select one file
     buttonLayout = qt.QHBoxLayout()
-    self.archetypeLabel = qt.QLabel("Filename pattern: ")
-    buttonLayout.addWidget(self.archetypeLabel)
     self.archetypeText = qt.QLineEdit()
     buttonLayout.addWidget(self.archetypeText)
     self.addFromArchetype = qt.QPushButton("Browse...")
     buttonLayout.addWidget(self.addFromArchetype)
-    filesFormLayout.addRow(buttonLayout)
     self.archetypeStartNumber = 0
 
-    # select a range of files
-    buttonLayout = qt.QHBoxLayout()
-    self.addByBrowsingButton = qt.QPushButton("Browse for files...")
-    self.clearButton = qt.QPushButton("Clear")
-    buttonLayout.addWidget(self.addByBrowsingButton)
-    buttonLayout.addWidget(self.clearButton)
-    filesFormLayout.addRow(buttonLayout)
+    filesFormLayout.addRow("Filename pattern: ", buttonLayout)
 
-    # file table
-    self.fileModel = qt.QStandardItemModel()
-    self.fileTable = qt.QTableView()
-    self.fileTable.horizontalHeader().stretchLastSection = True
-    self.fileTable.horizontalHeader().visible = False
-    self.fileTable.setModel(self.fileModel)
-    filesFormLayout.addRow(self.fileTable)
+    # file list group
+    fileListGroupBox = ctk.ctkCollapsibleGroupBox()
+    fileListGroupBox.title = "File list"
+    fileListLayout = qt.QVBoxLayout()
+    fileListGroupBox.setLayout(fileListLayout)
+    filesFormLayout.addRow("", fileListGroupBox)
 
-    # properties area for feedback
-    self.propertiesLabel = qt.QLabel()
-    filesFormLayout.addRow(self.propertiesLabel)
+    self.addByBrowsingButton = qt.QPushButton("Select files...")
+    fileListLayout.addWidget(self.addByBrowsingButton)
 
-    # spacing
-    self.spacing = slicer.qMRMLCoordinatesWidget()
+    self.fileTable = qt.QTextBrowser()
+    fileListLayout.addWidget(self.fileTable)
 
-    self.spacing.decimalsOption  = ctk.ctkDoubleSpinBox.DecimalsByKey | ctk.ctkDoubleSpinBox.DecimalsByShortcuts | ctk.ctkDoubleSpinBox.DecimalsByValue
-    self.spacing.minimum = 0.0
-    self.spacing.maximum = 1000000000.0
-    self.spacing.quantity = "length"
-    self.spacing.unitAwareProperties = slicer.qMRMLCoordinatesWidget.Precision | slicer.qMRMLCoordinatesWidget.Prefix | slicer.qMRMLCoordinatesWidget.Scaling | slicer.qMRMLCoordinatesWidget.Suffix
+    fileListGroupBox.collapsed = True
 
-    self.spacing.decimals = 8
-    self.spacing.coordinates = "1,1,1"
-    self.spacing.toolTip = "Set the colunm, row, slice spacing in mm; original spacing not including downsample"
-    filesFormLayout.addRow("Spacing: ", self.spacing)
+    # original volume size
+    self.originalVolumeSizeLabel = qt.QLabel()
+    filesFormLayout.addRow("Size: ", self.originalVolumeSizeLabel)
+
+    # reverse slice order
+    self.reverseCheckBox = qt.QCheckBox()
+    self.reverseCheckBox.toolTip = "Read the images in reverse order (flips loaded volume along IS axis)"
+    filesFormLayout.addRow("Reverse: ", self.reverseCheckBox)
+
+    # original spacing
+    self.spacingWidget = slicer.qMRMLCoordinatesWidget()
+    self.spacingWidget.setMRMLScene(slicer.mrmlScene)
+    self.spacingWidget.decimalsOption  = ctk.ctkDoubleSpinBox.DecimalsByKey | ctk.ctkDoubleSpinBox.DecimalsByShortcuts | ctk.ctkDoubleSpinBox.DecimalsByValue
+    self.spacingWidget.minimum = 0.0
+    self.spacingWidget.maximum = 1000000000.0
+    self.spacingWidget.quantity = "length"
+    self.spacingWidget.unitAwareProperties = slicer.qMRMLCoordinatesWidget.Precision | slicer.qMRMLCoordinatesWidget.Prefix | slicer.qMRMLCoordinatesWidget.Scaling | slicer.qMRMLCoordinatesWidget.Suffix
+    self.spacingWidget.coordinates = "1,1,1"
+    self.spacingWidget.toolTip = "Set the colunm, row, slice spacing; original spacing not including downsample"
+    filesFormLayout.addRow("Spacing: ", self.spacingWidget)
 
     #
     # output area
@@ -136,9 +141,7 @@ class ImageStacksWidget(ScriptedLoadableModuleWidget):
     # output volume selector
     #
     self.outputSelector = slicer.qMRMLNodeComboBox()
-
-    self.outputSelector.nodeTypes = ["vtkMRMLScalarVolumeNode",]
-
+    self.outputSelector.nodeTypes = ["vtkMRMLScalarVolumeNode"]
     self.outputSelector.showChildNodeTypes = False
     self.outputSelector.showHidden = False
     self.outputSelector.showChildNodeTypes = False
@@ -152,30 +155,74 @@ class ImageStacksWidget(ScriptedLoadableModuleWidget):
     self.outputSelector.setToolTip( "Pick the output volume to populate or None to autogenerate." )
     outputFormLayout.addRow("Output Volume: ", self.outputSelector)
 
-    self.downsample = qt.QCheckBox()
-    self.downsample.toolTip = "Reduces data size by half in each dimension by skipping every other pixel and slice (uses about 1/8 memory)"
-    outputFormLayout.addRow("Downsample: ", self.downsample)
+    #
+    # output ROI selector
+    #
+    self.outputROISelector = slicer.qMRMLNodeComboBox()
+    self.outputROISelector.nodeTypes = ["vtkMRMLAnnotationROINode", "vtkMRMLMarkupsROINode"]
+    self.outputROISelector.showChildNodeTypes = False
+    self.outputROISelector.showHidden = False
+    self.outputROISelector.showChildNodeTypes = False
+    self.outputROISelector.noneEnabled = True
+    self.outputROISelector.removeEnabled = True
+    self.outputROISelector.renameEnabled = True
+    self.outputROISelector.addEnabled = False
+    self.outputROISelector.noneDisplay = "(Full volume)"
+    self.outputROISelector.setMRMLScene( slicer.mrmlScene )
+    self.outputROISelector.setToolTip( "Set the region of the volume that will be loaded")
+    outputFormLayout.addRow("Region of interest: ", self.outputROISelector)
 
-    self.reverse = qt.QCheckBox()
-    self.reverse.toolTip = "Read the images in reverse order"
-    outputFormLayout.addRow("Reverse: ", self.reverse)
+    #
+    # Quality selector
+    #
+    qualityLayout = qt.QVBoxLayout()
+    self.qualityPreviewRadioButton = qt.QRadioButton("preview")
+    self.qualityHalfRadioButton = qt.QRadioButton("half resolution")
+    self.qualityFullRadioButton = qt.QRadioButton("full resolution")
+    qualityLayout.addWidget(self.qualityPreviewRadioButton)
+    qualityLayout.addWidget(self.qualityHalfRadioButton)
+    qualityLayout.addWidget(self.qualityFullRadioButton)
+    self.qualityPreviewRadioButton.setChecked(True)
+    outputFormLayout.addRow("Quality: ", qualityLayout)
 
-    self.sliceSkip = ctk.ctkDoubleSpinBox()
-    self.sliceSkip.decimals = 0
-    self.sliceSkip.minimum = 0
-    self.sliceSkip.toolTip = "Skips the selected number of slices between each pair of output volume slices (use, for example, on long thin samples with more slices than in-plane resolution)"
-    outputFormLayout.addRow("Slice skip: ", self.sliceSkip)
+    self.sliceSkipSpinBox = qt.QSpinBox()
+    self.sliceSkipSpinBox.toolTip = "Skips the selected number of slices between each pair of output volume slices (use, for example, on long thin samples with more slices than in-plane resolution)"
+    outputFormLayout.addRow("Slice skip: ", self.sliceSkipSpinBox)
+
+    # output volume size
+    self.outputVolumeSizeLabel = qt.QLabel()
+    outputFormLayout.addRow("Output size: ", self.outputVolumeSizeLabel)
+
+    # output volume spacing
+    self.outputSpacingWidget = slicer.qMRMLCoordinatesWidget()
+    self.outputSpacingWidget.setMRMLScene(slicer.mrmlScene)
+    self.outputSpacingWidget.readOnly = True
+    self.outputSpacingWidget.frame = False
+    self.outputSpacingWidget.decimalsOption  = ctk.ctkDoubleSpinBox.DecimalsByKey | ctk.ctkDoubleSpinBox.DecimalsByShortcuts | ctk.ctkDoubleSpinBox.DecimalsByValue
+    self.outputSpacingWidget.minimum = 0.0
+    self.outputSpacingWidget.maximum = 1000000000.0
+    self.outputSpacingWidget.quantity = "length"
+    self.outputSpacingWidget.unitAwareProperties = slicer.qMRMLCoordinatesWidget.Precision | slicer.qMRMLCoordinatesWidget.Prefix | slicer.qMRMLCoordinatesWidget.Scaling | slicer.qMRMLCoordinatesWidget.Suffix
+    self.outputSpacingWidget.coordinates = "1,1,1"
+    self.outputSpacingWidget.toolTip = "Slice spacing of the volume that will be loaded"
+    outputFormLayout.addRow("Output spacing: ", self.outputSpacingWidget)
 
     self.loadButton = qt.QPushButton("Load files")
-    self.loadButton.toolTip = "Populate the file list above using either the Browse for files or Select archetype buttons to enable this button"
+    self.loadButton.toolTip = "Load files as a 3D volume"
     self.loadButton.enabled = False
     outputFormLayout.addRow(self.loadButton)
 
     # connections
+    self.reverseCheckBox.connect('toggled(bool)', self.updateLogicFromWidget)
+    self.sliceSkipSpinBox.connect("valueChanged(int)", self.updateLogicFromWidget)
+    self.spacingWidget.connect("coordinatesChanged(double*)", self.updateLogicFromWidget)
+    self.qualityPreviewRadioButton.connect("toggled(bool)", lambda toggled, widget=self.qualityPreviewRadioButton: self.onQualityToggled(toggled, widget))
+    self.qualityHalfRadioButton.connect("toggled(bool)", lambda toggled, widget=self.qualityHalfRadioButton: self.onQualityToggled(toggled, widget))
+    self.qualityFullRadioButton.connect("toggled(bool)", lambda toggled, widget=self.qualityFullRadioButton: self.onQualityToggled(toggled, widget))
+    self.outputROISelector.connect("currentNodeChanged(vtkMRMLNode*)", self.setOutputROINode)
     self.addByBrowsingButton.connect('clicked()', self.addByBrowsing)
     self.addFromArchetype.connect('clicked()', self.selectArchetype)
     self.archetypeText.connect('textChanged(const QString &)', self.populateFromArchetype)
-    self.clearButton.connect('clicked()', self.onClear)
     self.loadButton.connect('clicked()', self.onLoadButton)
 
     # Add vertical spacer
@@ -184,48 +231,70 @@ class ImageStacksWidget(ScriptedLoadableModuleWidget):
     self.loadButton.enabled = False
 
   def cleanup(self):
-    pass
+    self.setOutputROINode(None)
+    self.removeObservers()
 
-  def updateFileProperties(self, properties):
-    text = ""
-    for prop in properties:
-      text += f"{prop}: {properties[prop]}\n"
-    text = text[:-1]
-    self.propertiesLabel.text = text
+  def updateWidgetFromLogic(self):
+    # Original volume size
+    if (self.logic.originalVolumeDimensions[0] == 0
+      and self.logic.originalVolumeDimensions[1] == 0
+      and self.logic.originalVolumeDimensions[2] == 0):
+      self.originalVolumeSizeLabel.text = ""
+      self.outputVolumeSizeLabel.text = ""
+      self.outputSpacingWidget.coordinates = "1,1,1"
+      self.loadButton.enabled = False
+      return
+
+    self.originalVolumeSizeLabel.text = ImageStacksLogic.humanizeImageSize(self.logic.originalVolumeDimensions, self.logic.originalVolumeVoxelDataType)
+
+    outputIJKToRAS, outputExtent = self.logic.outputVolumeGeometry()
+    outputVolumeDimensions = [outputExtent[i*2+1]-outputExtent[i*2]+1 for i in range(3)]
+    self.outputVolumeSizeLabel.text = ImageStacksLogic.humanizeImageSize(outputVolumeDimensions, self.logic.originalVolumeVoxelDataType)
+    outputSpacing = [numpy.linalg.norm(outputIJKToRAS[0:3,i]) for i in range(3)]
+    self.outputSpacingWidget.coordinates = f"{outputSpacing[0]},{outputSpacing[1]},{outputSpacing[2]}"
+
+    self.loadButton.enabled = True
+
+
+  def updateLogicFromWidget(self):
+    self.logic.reverseSliceOrder = self.reverseCheckBox.checked
+    self.logic.sliceSkip = self.sliceSkipSpinBox.value
+    spacingString = self.spacingWidget.coordinates
+    self.logic.setOriginalVolumeSpacing([float(element) for element in spacingString.split(",")])
+    self.updateWidgetFromLogic()
+
+  def onQualityToggled(self, toggled, widget):
+    if not toggled:
+      return
+    if widget==self.qualityPreviewRadioButton:
+      quality = 'preview'
+    elif widget==self.qualityHalfRadioButton:
+      quality = 'half'
+    else:
+      quality = 'full'
+    self.logic.outputQuality = quality
+    self.updateWidgetFromLogic()
 
   def onClear(self):
-    self.fileTable.model().clear()
-    self.updateFileProperties({})
+    self.fileTable.clear()
     self.outputSelector.currentNodeID = ""
-    self.loadButton.enabled = False
+    self.logic.filePaths = []
+    self.updateWidgetFromLogic()
 
   def addByBrowsing(self):
+    self.onClear()
     filePaths = qt.QFileDialog().getOpenFileNames()
-    self.addFilePaths(filePaths)
+    self.setFilePaths(filePaths)
 
-  def addFilePaths(self, filePaths):
-    for filePath in filePaths:
-      item = qt.QStandardItem()
-      item.setText(filePath)
-      self.fileModel.setItem(self.fileModel.rowCount(), 0, item)
-    self.loadButton.enabled = filePaths != []
-    properties = self.logic.calculateProperties(filePaths)
-    self.updateFileProperties(properties)
-    self.updateSpacingFromFilePaths(filePaths)
+  def setFilePaths(self, filePaths):
+    self.fileTable.plainText = '\n'.join(filePaths)
+    self.logic.filePaths = filePaths
 
-  def updateSpacingFromFilePaths(self, filePaths):
-    if not filePaths:
-      return
-    spacing = self.logic.getImageSpacing(filePaths[0])
-    if not spacing:
-      return
-    if spacing[0] == spacing[1]:
-      # If x and y spacing are the same then we assume that it is an isotropic volume
-      # and set z spacing to the same value
-      spacingZ = spacing[0]
-    else:
-      spacingZ = 1.0
-    self.spacing.coordinates = f"{spacing[0]},{spacing[1]},{spacingZ}"
+    # Use the spacing that we find in the image
+    spacing = self.logic.originalVolumeRecommendedSpacing
+    self.spacingWidget.coordinates = f"{spacing[0]},{spacing[1]},{spacing[2]}"
+
+    self.updateWidgetFromLogic()
 
   def selectArchetype(self):
     filePath = qt.QFileDialog().getOpenFileName()
@@ -265,18 +334,12 @@ class ImageStacksWidget(ScriptedLoadableModuleWidget):
     while True:
       filePath = archetypeFormat % fileIndex
       if os.path.exists(filePath):
-        item = qt.QStandardItem()
-        item.setText(filePath)
-        self.fileModel.setItem(self.fileModel.rowCount(), 0, item)
         filePaths.append(filePath)
       else:
         if fileIndex != 0:
           break
       fileIndex += 1
-    self.loadButton.enabled = filePaths != []
-    properties = self.logic.calculateProperties(filePaths)
-    self.updateFileProperties(properties)
-    self.updateSpacingFromFilePaths(filePaths)
+    self.setFilePaths(filePaths)
     self.archetypeText.text = archetypeFormat
 
   def currentNode(self):
@@ -295,21 +358,33 @@ class ImageStacksWidget(ScriptedLoadableModuleWidget):
     else:
       self.outputSelector.setCurrentNode(node)
 
-  def onLoadButton(self):
-    paths = []
-    for row in range(self.fileModel.rowCount()):
-      item = self.fileModel.item(row)
-      paths.append(item.text())
+  def setOutputROINode(self, roiNode):
+    if self.outputROINode:
+      self.removeObserver(self.outputROINode, vtk.vtkCommand.ModifiedEvent, self.onOutputROIModified)
+    self.outputROINode = roiNode
+    if self.outputROINode:
+      self.addObserver(self.outputROINode, vtk.vtkCommand.ModifiedEvent, self.onOutputROIModified)
+    self.onOutputROIModified()
 
-    properties = {}
-    spacingString = self.spacing.coordinates
-    properties['spacing'] = [float(element) for element in spacingString.split(",")]
-    properties['downsample'] = self.downsample.checked
-    properties['reverse'] = self.reverse.checked
-    properties['sliceSkip'] = self.sliceSkip.value
+  def onOutputROIModified(self, unused1=None, unused2=None):
+    outputBounds = None
+    if self.outputROINode:
+      center = [0.0, 0.0, 0.0]
+      radius = [0.0, 0.0, 0.0]
+      self.outputROINode.GetXYZ(center)
+      self.outputROINode.GetRadiusXYZ(radius)
+      outputBounds = [
+        center[0]-radius[0], center[0]+radius[0],
+        center[1]-radius[1], center[1]+radius[1],
+        center[2]-radius[2], center[2]+radius[2]
+        ]
+    self.logic.outputVolumeBounds = outputBounds
+    self.updateWidgetFromLogic()
+
+  def onLoadButton(self):
     qt.QApplication.setOverrideCursor(qt.Qt.WaitCursor)
     try:
-      outputNode = self.logic.loadByPaths(paths, self.currentNode(), properties)
+      outputNode = self.logic.loadVolume(self.currentNode())
       self.setCurrentNode(outputNode)
       qt.QApplication.restoreOverrideCursor()
     except Exception as e:
@@ -366,16 +441,33 @@ class ImageStacksFileDialog(object):
           ext = pathInfo.suffix().lower()
           if ext in acceptedFileExtensions:
             filesToAdd.append(localPath)
-    return filesToAdd
+
+    # Filter out files that are known to cause complications
+    # Currently, there is only one rule, but it is expected that more filtering rules wil be added in the future.
+    filteredFilesToAdd = []
+    for filePath in filesToAdd:
+      fileName = qt.QFileInfo(filePath).fileName()
+
+      # Ignore cone-beam image in Bruker Skyscan folder
+      # such as `left_side_damaged__rec_spr.bmp`
+      if fileName.endswith("spr.bmp"):
+        # skip this file
+        logging.debug(f"Skipping {filePath} - it looks like a Bruker Skyscan cone-beam image, not an image slice")
+        continue
+
+      filteredFilesToAdd.append(filePath)
+
+    return filteredFilesToAdd
 
   def dropEvent(self):
     slicer.util.selectModule('ImageStacks')
+    moduleWidget = slicer.modules.imagestacks.widgetRepresentation().self()
+    moduleWidget.onClear()
     if len(self.filesToAdd) == 1:
-      slicer.modules.imagestacks.widgetRepresentation().self().archetypeText.text = self.filesToAdd[0]
+      moduleWidget.archetypeText.text = self.filesToAdd[0]
     elif len(self.filesToAdd) > 1:
-      slicer.modules.imagestacks.widgetRepresentation().self().addFilePaths(self.filesToAdd)
+      moduleWidget.setFilePaths(self.filesToAdd)
     self.filesToAdd=[]
-
 
 #
 # ImageStacksLogic
@@ -391,7 +483,25 @@ class ImageStacksLogic(ScriptedLoadableModuleLogic):
   https://github.com/Slicer/Slicer/blob/master/Base/Python/slicer/ScriptedLoadableModule.py
   """
 
-  def humanizeByteCount(self,byteCount):
+  def __init__(self):
+    ScriptedLoadableModuleLogic.__init__(self)
+    self._filePaths = []
+    self.originalVolumeDimensions = [0, 0, 0]
+    self.originalVolumeIJKToRAS = numpy.diag([-1.0, -1.0, 1.0, 1.0])
+    self.originalVolumeRecommendedSpacing = [1.0, 1.0, 1.0]
+    self.originalVolumeVoxelDataType = numpy.dtype('uint8')
+    self.sliceSkip = 0
+    self.reverseSliceOrder = False
+    self.outputQuality = 'preview' # valid values: preview, half, full
+    # Bounds is stored as None (no bounds)
+    # or [min_R, max_R, min_A, max_A, min_S, max_S] if there is a valid bounding box.
+    # This variable uses RAS coordinate system (Slicer's internal coordinate system)
+    # but image coordinate system in files is always LPS, therefore we invert the
+    # sign of the first two axes when we compute image extents.
+    self.outputVolumeBounds = None
+
+  @staticmethod
+  def humanizeByteCount(byteCount):
     units = "bytes"
     for unit in ['kilobytes', 'megabytes', 'gigabytes', 'terabytes']:
       if byteCount > 1024:
@@ -399,36 +509,90 @@ class ImageStacksLogic(ScriptedLoadableModuleLogic):
         units = unit
     return(byteCount, units)
 
-  def getImageSpacing(self, filePath):
-    try:
-      reader = sitk.ImageFileReader()
-      reader.SetFileName(filePath)
-      image = reader.Execute()
-      return image.GetSpacing()
-    except:
-      return None
+  @staticmethod
+  def humanizeImageSize(dimensions, scalarType):
+    """Create human-readable string explaining the image extent and size"""
+    itemsize = scalarType.itemsize
+    volumeSize = (itemsize * dimensions[0] * dimensions[1] * dimensions[2])
+    byteCount, units = ImageStacksLogic.humanizeByteCount(volumeSize)
+    return f"{dimensions[0]} x {dimensions[1]} x {dimensions[2]} x {scalarType} = {byteCount:.3f} {units}"
 
-  def calculateProperties(self, filePaths):
-    properties = {}
-    if filePaths == []:
-      return properties
+  @property
+  def filePaths(self):
+    return self._filePaths
+
+  @filePaths.setter
+  def filePaths(self, filePaths):
+    """Store file paths and compute originalVolumeDimensions and originalVolumeRecommendedSpacing."""
+
+    self._filePaths = filePaths
+    self.originalVolumeDimensions = [0, 0, 0]
+    self.originalVolumeRecommendedSpacing = [1.0, 1.0, 1.0]
+
+    if not self._filePaths:
+      return
+
     reader = sitk.ImageFileReader()
-    reader.SetFileName(filePaths[0])
+    reader.SetFileName(self._filePaths[0])
     image = reader.Execute()
     sliceArray = sitk.GetArrayFromImage(image)
-    dimensions = ((*sliceArray.shape[:2]), len(filePaths))
-    itemsize = numpy.dtype(sliceArray.dtype).itemsize
-    volumeSize = (itemsize * dimensions[0] * dimensions[1] * dimensions[2])
-    byteCount, units = self.humanizeByteCount(volumeSize)
-    properties['Full volume size'] = f"{dimensions[0]} x {dimensions[1]} x {dimensions[2]} x {sliceArray.dtype} = {byteCount:.3f} {units}"
-    resampledDimensions = [i>>1 for i in dimensions]
-    byteCount, units = self.humanizeByteCount(resampledDimensions[0]*resampledDimensions[1]*resampledDimensions[2])
-    properties['Downsampled volume size'] = f"{resampledDimensions[0]} x {resampledDimensions[1]} x {resampledDimensions[2]} x {sliceArray.dtype} = {byteCount:.3f} {units}"
-    return(properties)
 
-  def loadByPaths(self, paths, outputNode, properties={}):
+    self.originalVolumeDimensions = [sliceArray.shape[1], sliceArray.shape[0], len(filePaths)]
+    self.originalVolumeVoxelDataType = numpy.dtype(sliceArray.dtype)
+
+    firstSliceSpacing = image.GetSpacing()
+    self.originalVolumeRecommendedSpacing = [firstSliceSpacing[1], firstSliceSpacing[0], 1.0]
+    
+    if firstSliceSpacing[0] == firstSliceSpacing[1]:
+      # If x and y spacing are the same then we assume that it is an isotropic volume
+      # and set z spacing to the same value
+      self.originalVolumeRecommendedSpacing[2] = firstSliceSpacing[0]
+
+  def setOriginalVolumeSpacing(self, spacing):
+    # Volume is in LPS, therefore we invert the first two axes
+    self.originalVolumeIJKToRAS = numpy.diag([-spacing[0], -spacing[1], spacing[2], 1.0])
+
+  def outputVolumeGeometry(self):
+    # spacing
+    spacingScale = numpy.array([1.0, 1.0, 1+self.sliceSkip])
+    if self.outputQuality == 'half':
+      spacingScale *= 2.0
+    elif self.outputQuality == 'preview':
+      spacingScale *= 4.0
+    ijkToRAS = numpy.dot(self.originalVolumeIJKToRAS, numpy.diag([spacingScale[0], spacingScale[1], spacingScale[2], 1.0]))
+
+    # extent
+    fullExtent = [0, 0, 0, 0, 0, 0]
+    for i in range(3):
+      fullExtent[i*2+1] = int(math.floor(self.originalVolumeDimensions[i]/spacingScale[i])) - 1
+    if self.outputVolumeBounds:
+      rasToIJK = numpy.linalg.inv(ijkToRAS)
+      extentIJK = vtk.vtkBoundingBox()
+      for cornerR in [self.outputVolumeBounds[0], self.outputVolumeBounds[1]]:
+        for cornerA in [self.outputVolumeBounds[2], self.outputVolumeBounds[3]]:
+          for cornerS in [self.outputVolumeBounds[4], self.outputVolumeBounds[5]]:
+            cornerIJK = numpy.dot(rasToIJK, [cornerR, cornerA, cornerS, 1.0])[0:3]
+            extentIJK.AddPoint(cornerIJK)
+      extent = [0,0,0,0,0,0]
+      for i in range(3):
+        extent[i*2] = int(math.floor(extentIJK.GetBound(i*2)-0.5))
+        if extent[i*2] < fullExtent[i*2]:
+          extent[i*2] = fullExtent[i*2]
+        extent[i*2+1] = int(math.ceil(extentIJK.GetBound(i*2+1)+0.5))
+        if extent[i*2+1] > fullExtent[i*2+1]:
+          extent[i*2+1] = fullExtent[i*2+1]
+    else:
+      extent = fullExtent
+
+    # origin
+    originRAS = numpy.dot(ijkToRAS, [extent[0], extent[2], extent[4], 1.0])[0:3]
+    ijkToRAS[0:3,3] = originRAS
+
+    return ijkToRAS, extent
+
+  def loadVolume(self, outputNode):
     """
-    Load the files in paths to outputNode with optional properties.
+    Load the files in paths to outputNode.
     TODO: currently downsample is done with nearest neighbor filtering
     (i.e. skip slices and take every other row/column).
     It would be better to do a high order spline or other
@@ -438,51 +602,47 @@ class ImageStacksLogic(ScriptedLoadableModuleLogic):
     and give good results for a pixel aligned 50% scale operation.
     """
 
-    if paths == []:
-      return
+    ijkToRAS, extent = self.outputVolumeGeometry()
+    outputSpacing = [numpy.linalg.norm(ijkToRAS[0:3,i]) for i in range(3)]
+    originalVolumeSpacing = [numpy.linalg.norm(self.originalVolumeIJKToRAS[0:3, i]) for i in range(3)]
 
-    spacing = (1,1,1)
-    if 'spacing' in properties:
-      spacing = properties['spacing']
+    stepSize = [int(outputSpacing[i] / originalVolumeSpacing[i]) for i in range(3)]
 
-    sliceSkip = 0
-    if 'sliceSkip' in properties:
-      sliceSkip = int(properties['sliceSkip'])
-    spacing[2] *= 1+sliceSkip
-    paths = paths[::1+sliceSkip]
+    paths = self._filePaths[::stepSize[2]]
 
-    reverse = 'reverse' in properties and properties['reverse']
-    if reverse:
+    if self.reverseSliceOrder:
       paths.reverse()
-
-    downsample = 'downsample' in properties and properties['downsample']
-    if downsample:
-      paths = paths[::2]
-      spacing = [element * 2. for element in spacing]
 
     volumeArray = None
     sliceIndex = 0
-    for path in paths:
+    firstArrayFullShape = None
+    for inputSliceIndex, path in enumerate(paths):
+      if inputSliceIndex < extent[4] or inputSliceIndex > extent[5]:
+        # out of selected bounds
+        continue
       reader = sitk.ImageFileReader()
       reader.SetFileName(path)
       image = reader.Execute()
       sliceArray = sitk.GetArrayFromImage(image)
       if len(sliceArray.shape) == 3:
         sliceArray = sitk.GetArrayFromImage(image)[:,:,0]
+      currentArrayFullShape = sliceArray.shape 
+      if firstArrayFullShape is None:
+        firstArrayFullShape = currentArrayFullShape
 
       if volumeArray is None:
-        sliceShape = sliceArray.shape
-        if downsample:
-          sliceShape = [math.ceil(element/2) for element in sliceShape]
-        shape = (len(paths), *sliceShape)
+        shape = [extent[5]-extent[4]+1, extent[3]-extent[2]+1, extent[1]-extent[0]+1]
         volumeArray = numpy.zeros(shape, dtype=sliceArray.dtype)
-      if downsample:
-        sliceArray = sliceArray[::2,::2]
+      sliceArray = sliceArray[
+        extent[2]*stepSize[1]:(extent[3]+1)*stepSize[1]:stepSize[1],
+        extent[0]*stepSize[0]:(extent[1]+1)*stepSize[0]:stepSize[0]]
       if (sliceIndex > 0) and (volumeArray[sliceIndex].shape != sliceArray.shape):
-        message = "There are multiple datasets in the folder. Please select a single file as a sample or specify a pattern.\nDetails:\n{0}{1} size is {2} x {3}\n\n{4} size is {5} x {6}".format(
-          "After downsampling:\n\n" if downsample else "",
+        logging.debug("After downsampling, {0} size is {1} x {2}\n\n{3} size is {4} x {5}".format(
           paths[0], volumeArray[0].shape[0], volumeArray[0].shape[1],
-          path, sliceArray.shape[0], sliceArray.shape[1])
+          path, sliceArray.shape[0], sliceArray.shape[1]))
+        message = "There are multiple datasets in the folder. Please select a single file as a sample or specify a pattern.\nDetails:\n{0} size is {1} x {2}\n\n{3} size is {4} x {5}".format(
+          paths[0], firstArrayFullShape[0], firstArrayFullShape[1],
+          path, currentArrayFullShape[0], currentArrayFullShape[1])
         raise ValueError(message)
       volumeArray[sliceIndex] = sliceArray
       sliceIndex += 1
@@ -495,15 +655,8 @@ class ImageStacksLogic(ScriptedLoadableModuleLogic):
       name = os.path.splitext(fileName)[0]
       outputNode.SetName(name)
 
-    ijkToRAS = vtk.vtkMatrix4x4()
-    ijkToRAS.Identity()
-    for index in range(3):
-      if (spacing[index] < 0):
-        spacing[index] = -1. * spacing[index]
-        ijkToRAS.SetElement(index, index, -1.)
+    ijkToRAS = slicer.util.vtkMatrixFromArray(ijkToRAS)
     outputNode.SetIJKToRASMatrix(ijkToRAS)
-    outputNode.SetSpacing(*spacing)
-
     slicer.util.updateVolumeFromArray(outputNode, volumeArray)
     slicer.util.setSliceViewerLayers(background=outputNode, fit=True)
     return outputNode


### PR DESCRIPTION
I've implemented full ROI support and all related features described in https://github.com/SlicerMorph/SlicerMorph/issues/138

Demo:

https://user-images.githubusercontent.com/307929/109107536-e5daec80-76ff-11eb-8132-98a6c49c29b6.mp4

Details:
- If a ROI is specified then only that image region is loaded, saving lots of memory and computation time.
- User can choose between 3 quality levels: preview (64x smaller volume), half resolution (8x smaller volume), and full resolution
- Show output spacing (helps with choosing parameters so that output volume is approximately isotropic)
- Automatically compute output volume size and spacing (based on current quality settings, ROI size, slice skip)
- Simplified File table (converted to textbox and put it in collapsible groupbox to save space)

