### PR TITLE
BUG: fix ExportAs Transformed menu

### DIFF
--- a/ExportAs/ExportAs.py
+++ b/ExportAs/ExportAs.py
@@ -80,7 +80,7 @@ class ExportAsSubjectHierarchyPlugin(AbstractScriptedSubjectHierarchyPlugin):
     if associatedNode is not None and associatedNode.IsA("vtkMRMLTransformableNode") and associatedNode.GetTransformNodeID():
       self.exportTransformedAsAction.visible = True
       self.exportTransformedAsAction.enabled = True
-      menuAndFlags.append([self.exportTransformedAsAction, True])
+      menuAndFlags.append([self.transformedMenu, True])
 
     # export without transforming menu entries
     if associatedNode is not None and associatedNode.IsA("vtkMRMLStorableNode"):


### PR DESCRIPTION
Wrong variable (action instead of menu) was being put in the
list so transformed actions never appeared.