### PR TITLE
Fix open3d install when cache folder name contains space

### DIFF
--- a/ALPACA/ALPACA.py
+++ b/ALPACA/ALPACA.py
@@ -144,7 +144,9 @@ class ALPACAWidget(ScriptedLoadableModuleWidget):
             slicer.util.infoDisplay('Error: please check the url of the open3d wheel in the script')
             progressDialog.close()
         slicer.util.pip_install(f'cpdalp')
-        slicer.util.pip_install(wheelPath)
+        # wheelPath may contain spaces, therefore pass it as a list (that avoids splitting
+        # the argument into multiple command-line arguments when there are spaces in the path)
+        slicer.util.pip_install([wheelPath])
       else:
         slicer.util.pip_install('pywinpty==1.1.6')
         slicer.util.pip_install('notebook==6.0.3')


### PR DESCRIPTION
Fixes the issue of pip_install splitting up input wheel path at spaces.
See https://discourse.slicer.org/t/installing-open3d-is-giving-an-error/17978/10?u=lassoan