### PR TITLE
Updates to support removal of soft dependencies

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,7 @@ set(EXTENSION_CONTRIBUTORS "Sara Rolfe (UW), Murat Maga (SCRI)")
 set(EXTENSION_DESCRIPTION "This extension enables retrieval, visualization, measurement and annotation of high-resolution specimen data from volumetric scans (CTs and MRs) or 3D surface scans.")
 set(EXTENSION_ICONURL "https://raw.githubusercontent.com/SlicerMorph/SlicerMorph/master/SlicerMorph_Color.png")
 set(EXTENSION_SCREENSHOTURLS "https://na-mic.github.io/ProjectWeek/PW30_2019_GranCanaria/Projects/SlicerMorphGeometricMorphometricToolset/SM_screen.png https://na-mic.github.io/ProjectWeek/PW30_2019_GranCanaria/Projects/SlicerMorphGeometricMorphometricToolset/SM2.png")
-set(EXTENSION_DEPENDS "SegmentEditorExtraEffects Sandbox SlicerIGT RawImageGuess SlicerDcm2nii SurfaceWrapSolidify") # Specified as a space separated string, a list or 'NA' if any
+set(EXTENSION_DEPENDS "SegmentEditorExtraEffects") # Specified as a space separated string, a list or 'NA' if any
 
 #-----------------------------------------------------------------------------
 # Extension dependencies

--- a/README.md
+++ b/README.md
@@ -65,12 +65,12 @@ Modules in SlicerMorph are organized in three broad categories:
 The following extension is installed automatically with SlicerMorph. Although it is not directly relied on by the modules, it is necessary for many workflows supoorted by SlicerMorph:
 - [**SegmentEditorExtraEffects:** Provides additional segmentation effects and utilities, such as our SplitSegment function that allows saving the 3D volume  into multiple smaller, individual volumes using the provided segmentation.](https://github.com/lassoan/SlicerSegmentEditorExtraEffects)
 
-## Manually installed dependencies 
+## Manually installed dependencies
 The following extension is required for using the SegmentEndocranium. Installation is prompted on opening this module.
 - [**SurfaceWrapSolidy:** A segment editor effect useful to extract endocasts of cranial and other spaces.](https://github.com/sebastianandress/Slicer-SurfaceWrapSolidify)
 
 ## Manually installed recommended extensions
-We  recommend that the user manually install the following extensions that provide useful convenience functions: 
+We  recommend that the user manually install the following extensions that provide useful convenience functions:
 - [**SlicerIGT:** Provides landmark driven registration (affine and deformable) of volumes and models.](https://github.com/SlicerIGT/SlicerIGT)
 - [**Sandbox:** Provides utilities like Cross-sectional Area from segments, Lights module for more in-depth lighting control and CurvePlanarReformat module for straightening of curved structures (e.g., coiled snake scans.](https://github.com/PerkLab/SlicerSandbox/)
 - [**DCM2NIIX:** Provides a user-interface for the DICOM to NIFTI converter DCM2NIIX. Ideal for stripping metadata from DICOM datasets.](https://github.com/rordenlab/dcm2niix)
@@ -82,7 +82,6 @@ We  recommend that the user manually install the following extensions that provi
 ## 3D Morphometrics and Image Analysis Short Course materials
 
 We actively use SlicerMorph to teach a week-long intense [short course on 3D Morphometrics and Image analysis](http://workshop.SlicerMorph.org). The feedback of the attendees help us prioritize feature development and refinement. We are grateful for the feedback of over 100 participants. [Click for contents from the latest workshop, Spring 2022](https://github.com/SlicerMorph/Spr_2022)
-
 
 ## Important Websites
 *	SlicerMorph project website: https://slicermorph.github.io (website list upcoming events, including monthly user group meeting. It also has pointers to some of the online specimen repositories).

--- a/README.md
+++ b/README.md
@@ -61,13 +61,19 @@ Modules in SlicerMorph are organized in three broad categories:
   - [**SlicerMorph Preferences:**](https://github.com/SlicerMorph/SlicerMorph/tree/master/Docs/MorphPreferences/) Users can choose to enable specific customizations that include keyboard shortcuts, and optimized settings for working with large 3D datasets using the Application Settings menu of 3D Slicer. See the documentation link for list of SlicerMorph specific keyboard shortcuts and modified settings.
 
 ## Dependencies
-SlicerMorph automatically installs these additional extensions as dependencies. It should be noted that none of the SlicerMorph specific functionality directly relies on these modules. Functionality in these extensions complements modules in SlicerMorph. Click on the links to get more information about these extensions.
-
+## Automatically installed recommended extensions
+The following extension is installed automatically with SlicerMorph. Although it is not directly relied on by the modules, it is necessary for many workflows supoorted by SlicerMorph:
 - [**SegmentEditorExtraEffects:** Provides additional segmentation effects and utilities, such as our SplitSegment function that allows saving the 3D volume  into multiple smaller, individual volumes using the provided segmentation.](https://github.com/lassoan/SlicerSegmentEditorExtraEffects)
+
+## Manually installed dependencies 
+The following extension is required for using the SegmentEndocranium. Installation is prompted on opening this module.
+- [**SurfaceWrapSolidy:** A segment editor effect useful to extract endocasts of cranial and other spaces.](https://github.com/sebastianandress/Slicer-SurfaceWrapSolidify)
+
+## Manually installed recommended extensions
+We  recommend that the user manually install the following extensions that provide useful convenience functions: 
 - [**SlicerIGT:** Provides landmark driven registration (affine and deformable) of volumes and models.](https://github.com/SlicerIGT/SlicerIGT)
 - [**Sandbox:** Provides utilities like Cross-sectional Area from segments, Lights module for more in-depth lighting control and CurvePlanarReformat module for straightening of curved structures (e.g., coiled snake scans.](https://github.com/PerkLab/SlicerSandbox/)
 - [**DCM2NIIX:** Provides a user-interface for the DICOM to NIFTI converter DCM2NIIX. Ideal for stripping metadata from DICOM datasets.](https://github.com/rordenlab/dcm2niix)
-- [**SurfaceWrapSolidy:** A segment editor effect useful to extract endocasts of cranial and other spaces.](https://github.com/sebastianandress/Slicer-SurfaceWrapSolidify)
 - [**RawImageGuess:** A module that enables the user to import proprietary imaging formats by specifying data type, image dimensions and endiness.](https://github.com/acetylsalicyl/SlicerRawImageGuess)
 
 ## SlicerMorph Tutorials

--- a/SegmentEndocranium/SegmentEndocranium.py
+++ b/SegmentEndocranium/SegmentEndocranium.py
@@ -44,7 +44,22 @@ class SegmentEndocraniumWidget(ScriptedLoadableModuleWidget, VTKObservationMixin
     VTKObservationMixin.__init__(self)  # needed for parameter node observation
     self.logic = None
     self._parameterNode = None
-
+    # Create segment editor to get access to effects
+    segmentEditorWidget = slicer.qMRMLSegmentEditorWidget()
+    # To show segment editor widget (useful for debugging): segmentEditorWidget.show()
+    segmentEditorWidget.setMRMLScene(slicer.mrmlScene)
+    if not segmentEditorWidget.effectByName("Wrap Solidify"):
+      if slicer.util.confirmOkCancelDisplay("SegmentEndocranium requires installation of the SurfaceWrapSolidify extension.\nClick OK to install and restart the application."):
+        extensionName = 'SurfaceWrapSolidify'
+        em = slicer.app.extensionsManagerModel()
+        if not em.isExtensionInstalled(extensionName):
+          extensionMetaData = em.retrieveExtensionMetadataByName(extensionName)
+          url = f"{em.serverUrl().toString()}/api/v1/item/{extensionMetaData['_id']}/download"
+          extensionPackageFilename = slicer.app.temporaryPath+'/'+extensionMetaData['_id']
+          slicer.util.downloadFile(url, extensionPackageFilename)
+          em.interactive = False  # Disable popups (automatically install dependencies)
+          em.installExtension(extensionPackageFilename)
+          slicer.util.restart()
   def setup(self):
     """
     Called when the user opens the module the first time and the widget is initialized.

--- a/SlicerMorphExtension.s4ext
+++ b/SlicerMorphExtension.s4ext
@@ -12,7 +12,7 @@ scmrevision master
 # list dependencies
 # - These should be names of other modules that have .s4ext files
 # - The dependencies will be built first
-depends     Auto3dgm SegmentEditorExtraEffects Sandbox SlicerIGT RawImageGuess SlicerDcm2nii SurfaceWrapSolidify
+depends     SegmentEditorExtraEffect
 
 # Inner build directory (default is .)
 build_subdirectory .


### PR DESCRIPTION
Discussed in ExtensionsIndex pull request: https://github.com/Slicer/ExtensionsIndex/pull/1825

- Removes all extension dependencies with the exception of SegmentEditorExtraEffects
- Updates SlicerMorph documentation with description of dependencies/recommended extensions
- Updates SegmentEndocranium to prompt installation of SurfaceWrapSolidfy on module initialization