### PR TITLE
BUG: FastModelAlign dependencies not installing automatically

### DIFF
--- a/FastModelAlign/FastModelAlign.py
+++ b/FastModelAlign/FastModelAlign.py
@@ -110,6 +110,14 @@ class FastModelAlignWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
         """
         ScriptedLoadableModuleWidget.setup(self)
 
+        # Install required packages by running alpaca_preview setup
+        try:
+          from itk import Fpfh
+          import cpdalp
+        except ModuleNotFoundError:
+          slicer.util.selectModule(slicer.modules.alpaca_preview)
+          slicer.util.selectModule(slicer.modules.fastmodelalign)
+
         # Load widget from .ui file (created by Qt Designer).
         # Additional widgets can be instantiated manually and added to self.layout.
         uiWidget = slicer.util.loadUI(self.resourcePath('UI/FastModelAlign.ui'))


### PR DESCRIPTION
The module depends on python libraries that are installed automatically by the alpaca_preview module. If it has not been opened, FastModelAlign will fail. This commit adds a check of these dependencies and switches to the Alpaca_preview module and back if not found, triggering the install.