### PR TITLE
Speedup Slicer startup delaying itk import in ALPACA

### DIFF
--- a/ALPACA/ALPACA.py
+++ b/ALPACA/ALPACA.py
@@ -21,29 +21,6 @@ import math
 # ALPACA
 #
 
-itkInstalled = False
-try:
-    import itk
-
-    itkInstalled = True
-except:
-    itkInstalled = False
-    pass
-
-
-def initializeITK():
-    if not itkInstalled:
-        return
-
-    # For loading itk library beforehand to avoid delay while usage
-    import itk
-
-    fpfh = itk.Fpfh.PointFeature.MF3MF3.New()
-
-
-if platform.system() != "Darwin":
-    initializeITK()
-
 
 class ALPACA(ScriptedLoadableModule):
     """Uses ScriptedLoadableModule base class, available at:
@@ -213,11 +190,10 @@ class ALPACAWidget(ScriptedLoadableModuleWidget):
         except ModuleNotFoundError as e:
             print("Module Not found. Please restart Slicer to load packages.")
 
-        # Needed to support Mac systems
-        if platform.system() == "Darwin":
-            with slicer.util.MessageDialog("Loading ALPACA relevant Packages..."):
-                with slicer.util.WaitCursor():
-                    fpfh = itk.Fpfh.PointFeature.MF3MF3.New()
+        with slicer.util.MessageDialog("Loading ALPACA relevant Packages..."):
+            slicer.app.processEvents()
+            with slicer.util.WaitCursor():
+                fpfh = itk.Fpfh.PointFeature.MF3MF3.New()
 
         # Load widget from .ui file (created by Qt Designer).
         uiWidget = slicer.util.loadUI(self.resourcePath("UI/ALPACA.ui"))

--- a/ALPACA/ALPACA.py
+++ b/ALPACA/ALPACA.py
@@ -164,7 +164,8 @@ class ALPACAWidget(ScriptedLoadableModuleWidget):
 
         if needInstall:
             progressDialog = slicer.util.createProgressDialog(
-                labelText="Installing ITK RANSAC, ITK FPFH. This may take a minute...",
+                windowTitle="Installing...",
+                labelText="Installing ALPACA Python packages. This may take a minute...",
                 maximum=0,
             )
             slicer.app.processEvents()
@@ -175,7 +176,7 @@ class ALPACAWidget(ScriptedLoadableModuleWidget):
                 slicer.util.pip_install(["itk_ransac==0.1.4"])
                 slicer.util.pip_install(f"cpdalp")
             except:
-                slicer.util.infoDisplay("Issue while installing the ITK pip packages")
+                slicer.util.infoDisplay("Issue while installing the ITK Python packages")
                 progressDialog.close()
             import itk
 

--- a/ALPACA/ALPACA.py
+++ b/ALPACA/ALPACA.py
@@ -191,10 +191,15 @@ class ALPACAWidget(ScriptedLoadableModuleWidget):
         except ModuleNotFoundError as e:
             print("Module Not found. Please restart Slicer to load packages.")
 
-        with slicer.util.MessageDialog("Loading ALPACA relevant Packages..."):
-            slicer.app.processEvents()
-            with slicer.util.WaitCursor():
-                fpfh = itk.Fpfh.PointFeature.MF3MF3.New()
+        progressDialog = slicer.util.createProgressDialog(
+            windowTitle="Importing...",
+            labelText="Importing ALPACA Python packages. This may take few seconds...",
+            maximum=0,
+        )
+        slicer.app.processEvents()
+        with slicer.util.WaitCursor():
+            fpfh = itk.Fpfh.PointFeature.MF3MF3.New()
+        progressDialog.close()
 
         # Load widget from .ui file (created by Qt Designer).
         uiWidget = slicer.util.loadUI(self.resourcePath("UI/ALPACA.ui"))


### PR DESCRIPTION
After installing SlicerMorph, restarting the application and selecting the ALPACA module, the following is now displayed:

<img width=50% src="https://github.com/SlicerMorph/SlicerMorph/assets/219043/c8157b48-b3c5-4a2b-9818-7922be76feb8"/>

-----

_Originally posted by @muratmaga in https://github.com/Slicer/Slicer/issues/7280#issue-1940714371_

> After slicermorph install, instantiating the modules takes a long time (this is related to itk libraries for ALPACA), sometimes as much as a minute after cold restarts. This is not a big deal, except the splash screen stays in the middle of the desktop and cannot be moved or  cannot be hidden by clicking it. It interferes with the user's ability to interact and work on the desktop, since the Slicer splash window is in the middle of the screen.

The progress dialog is not modal and should not prevent the user from switching and using other applications.



