### PR TITLE
Adds default rendering preset for DiceCT volumes

### DIFF
--- a/MorphPreferences/Resources/SlicerMorphRC.py
+++ b/MorphPreferences/Resources/SlicerMorphRC.py
@@ -226,6 +226,6 @@ def onNodeAdded(caller, event, calldata):
   GPUDisplayNode = isinstance(node, slicer.vtkMRMLGPURayCastVolumeRenderingDisplayNode)
   CPUDisplayNode = isinstance(node, slicer.vtkMRMLCPURayCastVolumeRenderingDisplayNode)
   if GPUDisplayNode or CPUDisplayNode:
-    qt.QTimer.singleShot(0, lambda: setVolumePropertyDiceCT(node))  
+    qt.QTimer.singleShot(0, lambda: setVolumePropertyDiceCT(node))
 
 slicer.mrmlScene.AddObserver(slicer.vtkMRMLScene.NodeAddedEvent, onNodeAdded)


### PR DESCRIPTION
Addresses DiceCT rendering preset discussed on Discourse: https://discourse.slicer.org/t/registering-a-volume-rendering-default-presets-automatically/32964