### PR TITLE
Change ALPACA scaling and projection options

### DIFF
--- a/ALPACA/ALPACA.py
+++ b/ALPACA/ALPACA.py
@@ -268,7 +268,7 @@ class ALPACAWidget(ScriptedLoadableModuleWidget):
         self.ui.landmarkOutputSelector.connect(
             "validInputChanged(bool)", self.onSelectMultiProcess
         )
-        self.ui.skipScalingMultiCheckBox.connect(
+        self.ui.scalingMultiCheckBox.connect(
             "toggled(bool)", self.onSelectMultiProcess
         )
         self.ui.replicateAnalysisCheckBox.connect(
@@ -385,9 +385,9 @@ class ALPACAWidget(ScriptedLoadableModuleWidget):
 
     def onSelect(self):
         # Enable run ALPACA button
-        self.ui.skipScalingMultiCheckBox.checked = self.ui.skipScalingCheckBox.checked
-        self.ui.skipProjectionCheckBoxMulti.checked = (
-            self.ui.skipProjectionCheckBox.checked
+        self.ui.scalingMultiCheckBox.checked = self.ui.scalingCheckBox.checked
+        self.ui.projectionCheckBoxMulti.checked = (
+            self.ui.projectionCheckBox.checked
         )
         self.ui.subsampleButton.enabled = bool(
             self.ui.sourceModelSelector.currentNode()
@@ -474,7 +474,7 @@ class ALPACAWidget(ScriptedLoadableModuleWidget):
         ) = logic.runSubsample(
             self.sourceModelNode_clone,
             self.targetModelNode,
-            self.ui.skipScalingCheckBox.checked,
+            self.ui.scalingCheckBox.checked,
             self.parameterDictionary,
             self.ui.poissonSubsampleCheckBox.checked,
         )
@@ -612,7 +612,7 @@ class ALPACAWidget(ScriptedLoadableModuleWidget):
             self.sourceFeatures,
             self.targetFeatures,
             self.voxelSize,
-            self.ui.skipScalingCheckBox.checked,
+            self.ui.scalingCheckBox.checked,
             self.parameterDictionary,
         )
 
@@ -691,7 +691,7 @@ class ALPACAWidget(ScriptedLoadableModuleWidget):
         self.outputPoints.GetDisplayNode().SetPointLabelsVisibility(False)
         slicer.mrmlScene.RemoveNode(self.inputPoints)
         #
-        if self.ui.skipProjectionCheckBox.checked:
+        if not self.ui.projectionCheckBox.checked:
             logic.propagateLandmarkTypes(self.sourceLMNode, self.outputPoints)
         else:
             print(":: Projecting landmarks to external surface")
@@ -736,7 +736,7 @@ class ALPACAWidget(ScriptedLoadableModuleWidget):
         folderNode.SetItemParent(nonProjectLMItem, newFolder)
         folderNode.SetItemParent(warpedSourceItem, newFolder)
         # Add projected points if they have been created
-        if not self.ui.skipProjectionCheckBox.isChecked():
+        if self.ui.projectionCheckBox.isChecked():
             finalLMItem = folderNode.GetItemByDataNode(self.projectedLandmarks)
             folderNode.SetItemParent(finalLMItem, newFolder)
         #
@@ -783,7 +783,7 @@ class ALPACAWidget(ScriptedLoadableModuleWidget):
                 manualLMs[i, :] = point
             # Source LM numpy array
             point2 = [0, 0, 0]
-            if not self.ui.skipProjectionCheckBox.isChecked():
+            if self.ui.projectionCheckBox.isChecked():
                 finalLMs = np.zeros(
                     shape=(self.projectedLandmarks.GetNumberOfControlPoints(), 3)
                 )
@@ -926,7 +926,7 @@ class ALPACAWidget(ScriptedLoadableModuleWidget):
 
     def onApplyLandmarkMulti(self):
         logic = ALPACALogic()
-        if self.ui.skipProjectionCheckBoxMulti.checked != 0:
+        if self.ui.projectionCheckBoxMulti.checked is False:
             projectionFactor = 0
         else:
             projectionFactor = self.ui.projectionFactorSlider.value / 100
@@ -936,7 +936,7 @@ class ALPACAWidget(ScriptedLoadableModuleWidget):
                 self.ui.sourceFiducialMultiSelector.currentPath,
                 self.ui.targetModelMultiSelector.currentPath,
                 self.ui.landmarkOutputSelector.currentPath,
-                self.ui.skipScalingMultiCheckBox.checked,
+                self.ui.scalingMultiCheckBox.checked,
                 projectionFactor,
                 self.ui.JSONFileFormatSelector.checked,
                 self.parameterDictionary,
@@ -955,7 +955,7 @@ class ALPACAWidget(ScriptedLoadableModuleWidget):
                         self.ui.sourceFiducialMultiSelector.currentPath,
                         self.ui.targetModelMultiSelector.currentPath,
                         datedOutputFolder,
-                        self.ui.skipScalingMultiCheckBox.checked,
+                        self.ui.scalingMultiCheckBox.checked,
                         projectionFactor,
                         self.ui.JSONFileFormatSelector.checked,
                         self.parameterDictionary,
@@ -1459,7 +1459,7 @@ class ALPACALogic(ScriptedLoadableModuleLogic):
         sourceLandmarkPath,
         targetModelDirectory,
         outputDirectory,
-        skipScaling,
+        scalingOption,
         projectionFactor,
         useJSONFormat,
         parameters,
@@ -1525,7 +1525,7 @@ class ALPACALogic(ScriptedLoadableModuleLogic):
                                 sourceLandmarkFile,
                                 targetFilePath,
                                 outputFilePath,
-                                skipScaling,
+                                scalingOption,
                                 projectionFactor,
                                 parameters,
                             )
@@ -1546,7 +1546,7 @@ class ALPACALogic(ScriptedLoadableModuleLogic):
                         sourceLandmarkPath,
                         targetFilePath,
                         outputFilePath,
-                        skipScaling,
+                        scalingOption,
                         projectionFactor,
                         parameters,
                     )
@@ -1557,7 +1557,7 @@ class ALPACALogic(ScriptedLoadableModuleLogic):
             "SourceLandmarks": sourceLMList,
             "Target": TargetModelList,
             "Output": outputDirectory,
-            "Skip scaling ?": bool(skipScaling),
+            "Scaling ?": bool(scalingOption),
         }
         extras.update(parameters)
         parameterFile = os.path.join(outputDirectory, "advancedParameters.txt")
@@ -1569,7 +1569,7 @@ class ALPACALogic(ScriptedLoadableModuleLogic):
         sourceLandmarkFile,
         targetFilePath,
         outputFilePath,
-        skipScaling,
+        scalingOption,
         projectionFactor,
         parameters,
         usePoisson=False,
@@ -1586,7 +1586,7 @@ class ALPACALogic(ScriptedLoadableModuleLogic):
             voxelSize,
             scaling,
         ) = self.runSubsample(
-            sourceModelNode, targetModelNode, skipScaling, parameters, usePoisson
+            sourceModelNode, targetModelNode, scalingOption, parameters, usePoisson
         )
         SimilarityTransform, similarityFlag = self.estimateTransform(
             sourcePoints,
@@ -1594,7 +1594,7 @@ class ALPACALogic(ScriptedLoadableModuleLogic):
             sourceFeatures,
             targetFeatures,
             voxelSize,
-            skipScaling,
+            scalingOption,
             parameters,
         )
         # Rigid
@@ -1918,7 +1918,7 @@ class ALPACALogic(ScriptedLoadableModuleLogic):
         number_of_iterations,
         number_of_ransac_points,
         inlier_value,
-        skip_scaling,
+        scalingOption,
         check_edge_length,
         correspondence_distance,
     ):
@@ -1985,7 +1985,7 @@ class ALPACALogic(ScriptedLoadableModuleLogic):
             itk.MultiThreaderBase.ThreaderTypeFromString("POOL")
         )
         maximumDistance = inlier_value
-        if skip_scaling:
+        if not scalingOption:
             TransformType = itk.VersorRigid3DTransform[itk.D]
             RegistrationEstimatorType = itk.Ransac.LandmarkRegistrationEstimator[
                 6, TransformType
@@ -2441,7 +2441,7 @@ class ALPACALogic(ScriptedLoadableModuleLogic):
         sourceFeatures,
         targetFeatures,
         voxelSize,
-        skipScaling,
+        scalingOption,
         parameters,
     ):
         import itk
@@ -2489,7 +2489,7 @@ class ALPACALogic(ScriptedLoadableModuleLogic):
                 number_of_iterations=parameters["maxRANSAC"],
                 number_of_ransac_points=3,
                 inlier_value=float(parameters["distanceThreshold"]) * voxelSize,
-                skip_scaling=True,
+                scalingOption=False,
                 check_edge_length=True,
                 correspondence_distance=0.9,
             )
@@ -2532,7 +2532,7 @@ class ALPACALogic(ScriptedLoadableModuleLogic):
 
         print("Best Fitness without Scaling ", best_fitness, " RMSE is ", best_rmse)
 
-        if not skipScaling:
+        if scalingOption:
             maxAttempts = 10
             attempt = 0
 
@@ -2549,7 +2549,7 @@ class ALPACALogic(ScriptedLoadableModuleLogic):
                     number_of_iterations=ransac_iterations,
                     number_of_ransac_points=ransac_points,
                     inlier_value=float(parameters["distanceThreshold"]) * voxelSize,
-                    skip_scaling=False,
+                    scalingOption=True,
                     check_edge_length=False,
                     correspondence_distance=correspondence_distance,
                 )
@@ -2746,7 +2746,7 @@ class ALPACALogic(ScriptedLoadableModuleLogic):
         self,
         sourceModel,
         targetModel,
-        skipScaling,
+        scalingOption,
         parameters,
         usePoissonSubsample=False,
     ):
@@ -2778,16 +2778,16 @@ class ALPACALogic(ScriptedLoadableModuleLogic):
         print("Scale length are  ", fixedlength, movinglength)
         print("Voxel Size is ", voxel_size)
 
-        scaling = fixedlength / movinglength
+        scalingFactor = fixedlength / movinglength
 
         points = vtk_meshes[1].GetPoints()
         pointdata = points.GetData()
         points_as_numpy = numpy_support.vtk_to_numpy(pointdata)
 
-        if skipScaling != 0:
-            scaling = 1
-            print("Scaling factor is ", scaling)
-        points_as_numpy = points_as_numpy * scaling
+        if scalingOption is False:
+            scalingFactor = 1
+            print("Scaling factor is ", scalingFactor)
+        points_as_numpy = points_as_numpy * scalingFactor
         self.set_numpy_points_in_vtk(vtk_meshes[1], points_as_numpy)
 
         sourceFullMesh_vtk = vtk_meshes[1]
@@ -3137,7 +3137,7 @@ class ALPACALogic(ScriptedLoadableModuleLogic):
             sourceModelNode = slicer.util.loadModel(sourceFilePath)
             sourceModelNode.GetDisplayNode().SetVisibility(False)
             rootName = os.path.splitext(file)[0]
-            skipScalingOption = False
+            scalingOption = True
             (
                 sourcePoints,
                 targetPoints,
@@ -3148,7 +3148,7 @@ class ALPACALogic(ScriptedLoadableModuleLogic):
             ) = self.runSubsample(
                 sourceModelNode,
                 targetModelNode,
-                skipScalingOption,
+                scalingOption,
                 parameterDictionary,
                 usePoisson,
             )
@@ -3158,7 +3158,7 @@ class ALPACALogic(ScriptedLoadableModuleLogic):
                 sourceFeatures,
                 targetFeatures,
                 voxelSize,
-                skipScalingOption,
+                scalingOption,
                 parameterDictionary,
             )
 
@@ -3224,9 +3224,9 @@ class ALPACALogic(ScriptedLoadableModuleLogic):
             inputFilePaths, LMExclusionList, extension
         )
         shape = LM.lmOrig.shape
-        skipScalingOption = 0
+        scalingOption = False
         try:
-            LM.doGpa(skipScalingOption)
+            LM.doGpa(scalingOption)
         except ValueError:
             print(
                 "Point clouds may not have been generated correctly. Please re-run the point cloud generation step."

--- a/ALPACA/Resources/UI/ALPACA.ui
+++ b/ALPACA/Resources/UI/ALPACA.ui
@@ -161,30 +161,36 @@
            </widget>
           </item>
           <item row="4" column="0">
-           <widget class="QLabel" name="skipScalingLabel">
+           <widget class="QLabel" name="scalingLabel">
             <property name="text">
-             <string>Skip scaling</string>
+             <string>Scaling</string>
             </property>
            </widget>
           </item>
           <item row="4" column="1">
-           <widget class="QCheckBox" name="skipScalingCheckBox">
+           <widget class="QCheckBox" name="scalingCheckBox">
             <property name="toolTip">
              <string>If checked, ALPACA will skip scaling during alignment (Not recommended).</string>
+            </property>
+            <property name="checked">
+             <bool>true</bool>
             </property>
            </widget>
           </item>
           <item row="5" column="0">
-           <widget class="QLabel" name="skipProjectionLabel">
+           <widget class="QLabel" name="projectionLabel">
             <property name="text">
-             <string>Skip projection</string>
+             <string>Projection</string>
             </property>
            </widget>
           </item>
           <item row="5" column="1">
-           <widget class="QCheckBox" name="skipProjectionCheckBox">
+           <widget class="QCheckBox" name="projectionCheckBox">
             <property name="toolTip">
              <string>If checked, ALPACA will skip landmark projection towards the target surface.</string>
+            </property>
+            <property name="checked">
+             <bool>true</bool>
             </property>
            </widget>
           </item>
@@ -215,7 +221,7 @@
             <property name="singleStep" stdset="0">
              <double>0.100000000000000</double>
             </property>
-            <property name="maximum">
+            <property name="maximum" stdset="0">
              <double>2.000000000000000</double>
             </property>
             <property name="value" stdset="0">
@@ -440,10 +446,7 @@
             <property name="toolTip">
              <string>Select the source model</string>
             </property>
-            <property name="filters">
-             <set>ctkPathLineEdit::Files</set>
-            </property>
-            <property name="nameFilters">
+            <property name="nameFilters" stdset="0">
              <stringlist>
               <string>*.ply *.obj *.vtk</string>
              </stringlist>
@@ -462,10 +465,7 @@
             <property name="toolTip">
              <string>Select the source landmarks</string>
             </property>
-            <property name="filters">
-             <set>ctkPathLineEdit::Files|ctkPathLineEdit::NoDot|ctkPathLineEdit::NoDotDot|ctkPathLineEdit::Readable</set>
-            </property>
-            <property name="nameFilters">
+            <property name="nameFilters" stdset="0">
              <stringlist>
               <string>*.fcsv *.json *.mrk.json</string>
              </stringlist>
@@ -484,9 +484,6 @@
             <property name="toolTip">
              <string>Select the directory of models to be landmarked</string>
             </property>
-            <property name="filters">
-             <set>ctkPathLineEdit::Dirs|ctkPathLineEdit::Drives</set>
-            </property>
            </widget>
           </item>
           <item row="5" column="0">
@@ -500,9 +497,6 @@
            <widget class="ctkPathLineEdit" name="landmarkOutputSelector" native="true">
             <property name="toolTip">
              <string>Select the output directory where the landmarks will be saved</string>
-            </property>
-            <property name="filters">
-             <set>ctkPathLineEdit::Dirs|ctkPathLineEdit::Drives</set>
             </property>
            </widget>
           </item>
@@ -678,20 +672,20 @@
            </widget>
           </item>
           <item row="0" column="1">
-           <widget class="ctkSliderWidget" name="normalSearchRadiusSlider">
+           <widget class="ctkSliderWidget" name="normalSearchRadiusSlider" native="true">
             <property name="toolTip">
              <string>Set size of the neighborhood radius used when computing normals</string>
             </property>
-            <property name="decimals">
+            <property name="decimals" stdset="0">
              <number>0</number>
             </property>
-            <property name="minimum">
-             <double>0.1000000000000000</double>
+            <property name="minimum" stdset="0">
+             <double>0.100000000000000</double>
             </property>
-            <property name="maximum">
-		    <double>10.000000000000000</double>
+            <property name="maximum" stdset="0">
+             <double>10.000000000000000</double>
             </property>
-            <property name="value">
+            <property name="value" stdset="0">
              <double>2.000000000000000</double>
             </property>
            </widget>
@@ -757,13 +751,13 @@
             <property name="decimals" stdset="0">
              <number>0</number>
             </property>
-            <property name="maximum">
+            <property name="maximum" stdset="0">
              <double>10000000.000000000000000</double>
             </property>
             <property name="singleStep" stdset="0">
-             <double>1000.00000000000000</double>
+             <double>1000.000000000000000</double>
             </property>
-            <property name="value">
+            <property name="value" stdset="0">
              <double>1000000.000000000000000</double>
             </property>
            </widget>
@@ -816,20 +810,20 @@
            </widget>
           </item>
           <item row="6" column="1">
-           <widget class="ctkSliderWidget" name="FPFHNeighborsSlider">
+           <widget class="ctkSliderWidget" name="FPFHNeighborsSlider" native="true">
             <property name="toolTip">
              <string>Set size of the max neighborhood points used when computing FPFH</string>
             </property>
-            <property name="decimals">
+            <property name="decimals" stdset="0">
              <number>0</number>
             </property>
-            <property name="minimum">
+            <property name="minimum" stdset="0">
              <double>10.000000000000000</double>
             </property>
-            <property name="maximum">
-		    <double>200.000000000000000</double>
+            <property name="maximum" stdset="0">
+             <double>200.000000000000000</double>
             </property>
-            <property name="value">
+            <property name="value" stdset="0">
              <double>100.000000000000000</double>
             </property>
            </widget>
@@ -867,14 +861,14 @@
             <property name="decimals" stdset="0">
              <number>1</number>
             </property>
-            <property name="minimum">
+            <property name="minimum" stdset="0">
              <double>0.010000000000000</double>
             </property>
-            <property name="maximum">
+            <property name="maximum" stdset="0">
              <double>20.000000000000000</double>
             </property>
-            <property name="singleStep">
-             <double>0.0500000000000000</double>
+            <property name="singleStep" stdset="0">
+             <double>0.050000000000000</double>
             </property>
             <property name="value" stdset="0">
              <double>2.000000000000000</double>
@@ -896,14 +890,14 @@
             <property name="decimals" stdset="0">
              <number>1</number>
             </property>
-            <property name="minimum">
+            <property name="minimum" stdset="0">
              <double>0.010000000000000</double>
             </property>
-            <property name="maximum">
+            <property name="maximum" stdset="0">
              <double>20.000000000000000</double>
             </property>
-            <property name="singleStep">
-             <double>0.0500000000000000</double>
+            <property name="singleStep" stdset="0">
+             <double>0.050000000000000</double>
             </property>
             <property name="value" stdset="0">
              <double>2.000000000000000</double>
@@ -988,15 +982,12 @@
             <property name="toolTip">
              <string>Select the directory of containing the compiled BCPD</string>
             </property>
-            <property name="filters">
-             <set>ctkPathLineEdit::Dirs</set>
-            </property>
            </widget>
           </item>
          </layout>
         </widget>
-	   </item>
-	   <item>
+       </item>
+       <item>
         <widget class="ctkCollapsibleButton" name="outputFormatWidget" native="true">
          <property name="sizePolicy">
           <sizepolicy hsizetype="Minimum" vsizetype="MinimumExpanding">
@@ -1027,7 +1018,7 @@
             </property>
            </widget>
           </item>
-          <item row="0" column="2">
+          <item row="0" column="1">
            <widget class="QRadioButton" name="FCSVFileFormatSelector">
             <property name="enabled">
              <bool>true</bool>
@@ -1074,9 +1065,6 @@
             <property name="toolTip">
              <string>Select directory containing models for template selection</string>
             </property>
-            <property name="filters">
-             <set>ctkPathLineEdit::Dirs</set>
-            </property>
            </widget>
           </item>
           <item row="1" column="0">
@@ -1105,10 +1093,7 @@
             <property name="toolTip">
              <string>The default reference model for downsampling point clouds with matching points will be the first specimen. Users can also manually select a reference model here </string>
             </property>
-            <property name="filters">
-             <set>ctkPathLineEdit::Files</set>
-            </property>
-            <property name="nameFilters">
+            <property name="nameFilters" stdset="0">
              <stringlist>
               <string>*.ply</string>
               <string>*.obj</string>
@@ -1129,9 +1114,6 @@
            <widget class="ctkPathLineEdit" name="kmeansOutputSelector" native="true">
             <property name="toolTip">
              <string>Specify the output directory for the kmeans multi-template selection output</string>
-            </property>
-            <property name="filters">
-             <set>ctkPathLineEdit::Dirs</set>
             </property>
            </widget>
           </item>

--- a/ALPACA/Resources/UI/ALPACA.ui
+++ b/ALPACA/Resources/UI/ALPACA.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>730</width>
-    <height>743</height>
+    <height>828</height>
    </rect>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
@@ -170,7 +170,7 @@
           <item row="4" column="1">
            <widget class="QCheckBox" name="scalingCheckBox">
             <property name="toolTip">
-             <string>If checked, ALPACA will skip scaling during alignment (Not recommended).</string>
+             <string>If checked, ALPACA will include scaling in alignment (recommended).</string>
             </property>
             <property name="checked">
              <bool>true</bool>
@@ -187,7 +187,7 @@
           <item row="5" column="1">
            <widget class="QCheckBox" name="projectionCheckBox">
             <property name="toolTip">
-             <string>If checked, ALPACA will skip landmark projection towards the target surface.</string>
+             <string>If checked, ALPACA will include landmark projection towards the target surface.</string>
             </property>
             <property name="checked">
              <bool>true</bool>
@@ -501,30 +501,36 @@
            </widget>
           </item>
           <item row="6" column="0">
-           <widget class="QLabel" name="skipScalingMultiCheckBoxLabel">
+           <widget class="QLabel" name="scalingMultiCheckBoxLabel">
             <property name="text">
-             <string>Skip scaling</string>
+             <string>Scaling</string>
             </property>
            </widget>
           </item>
           <item row="6" column="1">
-           <widget class="QCheckBox" name="skipScalingMultiCheckBox">
+           <widget class="QCheckBox" name="scalingMultiCheckBox">
             <property name="toolTip">
-             <string>If checked, ALPACA will skip scaling during the alignment.</string>
+             <string>If checked, ALPACA will include scaling during the alignment.</string>
+            </property>
+            <property name="checked">
+             <bool>true</bool>
             </property>
            </widget>
           </item>
           <item row="7" column="0">
-           <widget class="QLabel" name="skipProjectionCheckBoxMultiLabel">
+           <widget class="QLabel" name="projectionCheckBoxMultiLabel">
             <property name="text">
-             <string>Skip projection</string>
+             <string>Projection</string>
             </property>
            </widget>
           </item>
           <item row="7" column="1">
-           <widget class="QCheckBox" name="skipProjectionCheckBoxMulti">
+           <widget class="QCheckBox" name="projectionCheckBoxMulti">
             <property name="toolTip">
-             <string>If checked, ALPACA will skip final refinement step placing landmarks on the target surface.</string>
+             <string>If checked, ALPACA will include final refinement step placing landmarks on the target surface.</string>
+            </property>
+            <property name="checked">
+             <bool>true</bool>
             </property>
            </widget>
           </item>

--- a/ImageStacks/ImageStacks.py
+++ b/ImageStacks/ImageStacks.py
@@ -469,7 +469,8 @@ class ImageStacksFileDialog:
   @staticmethod
   def pathsFromMimeData(mimeData):
     filesToAdd = []
-    acceptedFileExtensions = ['jpg', 'jpeg', 'tif', 'tiff', 'png', 'bmp', 'jp2', 'nrrd', 'nhdr']
+    #acceptedFileExtensions = ['jpg', 'jpeg', 'tif', 'tiff', 'png', 'bmp', 'jp2', 'nrrd', 'nhdr']
+    acceptedFileExtensions = ['jpg', 'jpeg', 'tif', 'tiff', 'png', 'bmp', 'jp2']
     if mimeData.hasFormat('text/uri-list'):
       urls = mimeData.urls()
       for url in urls:


### PR DESCRIPTION
This commit changes the ALPACA scaling checkboxes from "Skip scaling", unchecked by default, to "Scaling", checked by default. The same change is made to the projection checkboxes.

The variable "skipScaling" is updated to "scalingOption", which is "True" when scaling is selected, the variable "scaling" is updated to "scalingFactor" to avoid ambiguity, and the module logic has been updated to reflect these changes.