### PR TITLE
ENH: Update ALPACA module for compatibility with ITK 5.4 and SlicerANTs

### DIFF
--- a/ALPACA/ALPACA.py
+++ b/ALPACA/ALPACA.py
@@ -115,10 +115,10 @@ class ALPACAWidget(ScriptedLoadableModuleWidget):
             )
             slicer.app.processEvents()
             try:
-                slicer.util.pip_install(["itk==5.3.0"])
+                slicer.util.pip_install(["itk~=5.4.0"])
                 slicer.util.pip_install(["scikit-learn"])
-                slicer.util.pip_install(["itk_fpfh==0.1.1"])
-                slicer.util.pip_install(["itk_ransac==0.1.4"])
+                slicer.util.pip_install(["itk-fpfh~=0.2.0"])
+                slicer.util.pip_install(["itk-ransac~=0.2.1"])
                 slicer.util.pip_install(f"cpdalp")
             except:
                 slicer.util.infoDisplay("Issue while installing the ITK Python packages")


### PR DESCRIPTION
This commit updates the ALPACA module to support use alongside the `itk-ants` package, which requires ITK 5.4 and is installed via the ITKANTsCommon module provided by the SlicerANTs extension.

The ALPACA module now requires the following packages:
- itk `>= 5.4.0, == 5.4.*`
- itk-fpfh `>= 0.2.0, == 0.2.*`
- itk-ransac `>= 0.2.1, == 0.2.*`

This pull request is expected to fix the following issue:
* https://github.com/Slicer/Slicer/issues/7789