### PR TITLE
Fix logic inversion for scaling parameter in FastModelAlign

### DIFF
--- a/ALPACA/ALPACA.py
+++ b/ALPACA/ALPACA.py
@@ -2784,13 +2784,9 @@ class ALPACALogic(ScriptedLoadableModuleLogic):
         sourceModelMesh = sourceModel.GetMesh()
         targetModelMesh = targetModel.GetMesh()
 
-        vtk_meshes = []
-        vtk_meshes.append(targetModelMesh)
-        vtk_meshes.append(sourceModelMesh)
-
         # Scale the mesh and the landmark points
-        fixedBoxLengths, fixedlength = self.getBoxLengths(vtk_meshes[0])
-        movingBoxLengths, movinglength = self.getBoxLengths(vtk_meshes[1])
+        fixedBoxLengths, fixedlength = self.getBoxLengths(targetModelMesh)
+        movingBoxLengths, movinglength = self.getBoxLengths(sourceModelMesh)
 
         # Sub-Sample the points for rigid refinement and deformable registration
         point_density = parameters["pointDensity"]
@@ -2808,8 +2804,8 @@ class ALPACALogic(ScriptedLoadableModuleLogic):
             scalingFactor = 1
         print("Scaling factor is ", scalingFactor)
 
-        sourceFullMesh_vtk = self.scale_vtk_point_coordinates(vtk_meshes[1], scalingFactor)
-        targetFullMesh_vtk = vtk_meshes[0]
+        sourceFullMesh_vtk = self.scale_vtk_point_coordinates(sourceModelMesh, scalingFactor)
+        targetFullMesh_vtk = targetModelMesh
 
         if usePoissonSubsample:
             print("Using Poisson Point Subsampling Method")

--- a/ALPACA/ALPACA.py
+++ b/ALPACA/ALPACA.py
@@ -2736,7 +2736,7 @@ class ALPACALogic(ScriptedLoadableModuleLogic):
         normals.SetInputData(mesh)
         normals.Update()
         out1 = normals.GetOutput()
-        normal_array = numpy_support.vtk_to_numpy(out1.GetPoints().GetData())
+        normal_array = numpy_support.vtk_to_numpy(out1.GetPointData().GetNormals())
         point_array = numpy_support.vtk_to_numpy(mesh.GetPoints().GetData())
         return point_array, normal_array
 

--- a/FastModelAlign/FastModelAlign.py
+++ b/FastModelAlign/FastModelAlign.py
@@ -264,7 +264,7 @@ class FastModelAlignWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
         ) = logic.runSubsample(
             self.sourceModelNode_clone,
             self.targetModelNode,
-            self.ui.skipScalingCheckBox.checked,
+            self.ui.scalingCheckBox.checked,
             self.parameterDictionary,
             self.ui.poissonSubsampleCheckBox.checked,
         )
@@ -332,7 +332,7 @@ class FastModelAlignWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
         self.targetModelNode = self.ui.targetModelSelector.currentNode()
         logic = FastModelAlignLogic()
 
-        self.sourcePoints, self.targetPoints, self.scalingTransformNode, self.ICPTransformNode = logic.ITKRegistration(self.sourceModelNode, self.targetModelNode, self.ui.skipScalingCheckBox.checked,
+        self.sourcePoints, self.targetPoints, self.scalingTransformNode, self.ICPTransformNode = logic.ITKRegistration(self.sourceModelNode, self.targetModelNode, self.ui.scalingCheckBox.checked,
             self.parameterDictionary, self.ui.poissonSubsampleCheckBox.checked)
 
         scalingNodeName = self.sourceModelName + "_scaling"
@@ -353,7 +353,7 @@ class FastModelAlignWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
 
         slicer.mrmlScene.RemoveNode(self.sourceModelNode)
 
-        if self.ui.skipScalingCheckBox.checked:
+        if not self.ui.scalingCheckBox.checked:
             slicer.mrmlScene.RemoveNode(self.scalingTransformNode)
 
         self.ui.runCPDAffineButton.enabled = True
@@ -437,7 +437,7 @@ class FastModelAlignLogic(ScriptedLoadableModuleLogic):
         ScriptedLoadableModuleLogic.__init__(self)
 
 
-    def ITKRegistration(self, sourceModelNode, targetModelNode, skipScalingOption, parameterDictionary, usePoisson):
+    def ITKRegistration(self, sourceModelNode, targetModelNode, scalingOption, parameterDictionary, usePoisson):
         import ALPACA
         logic = ALPACA.ALPACALogic()
         (
@@ -450,7 +450,7 @@ class FastModelAlignLogic(ScriptedLoadableModuleLogic):
         ) = logic.runSubsample(
             sourceModelNode,
             targetModelNode,
-            skipScalingOption,
+            scalingOption,
             parameterDictionary,
             usePoisson,
         )
@@ -475,7 +475,7 @@ class FastModelAlignLogic(ScriptedLoadableModuleLogic):
             sourceFeatures,
             targetFeatures,
             voxelSize,
-            skipScalingOption,
+            scalingOption,
             parameterDictionary,
         )
 
@@ -613,7 +613,7 @@ class FastModelAlignTest(ScriptedLoadableModuleTest):
 
 
         self.sourcePoints_test, self.targetPoints_test, self.scalingTransformNode_test, self.ICPTransformNode_test = logic.ITKRegistration(self.sourceModelNode_test, self.targetModelNode_test, False,
-            self.parameterDictionary_test, False)
+            self.parameterDictionary_test, True)
 
         scalingNodeName_test = self.sourceModelName_test + "_scaling_test"
         rigidNodeName_test = self.sourceModelName_test + "_rigid_test"

--- a/FastModelAlign/Resources/UI/FastModelAlign.ui
+++ b/FastModelAlign/Resources/UI/FastModelAlign.ui
@@ -108,16 +108,19 @@
            </widget>
           </item>
           <item row="2" column="0">
-           <widget class="QLabel" name="skipScalingLabel">
+           <widget class="QLabel" name="scalingLabel">
             <property name="text">
-             <string>Skip scaling</string>
+             <string>Apply scaling</string>
             </property>
            </widget>
           </item>
           <item row="2" column="1">
-           <widget class="QCheckBox" name="skipScalingCheckBox">
+           <widget class="QCheckBox" name="scalingCheckBox">
             <property name="toolTip">
-             <string>If checked, ALPACA will skip scaling during alignment (Not recommended).</string>
+             <string>Whether to apply scaling during alignment (highly recommended).</string>
+            </property>
+            <property name="checked">
+             <bool>true</bool>
             </property>
            </widget>
           </item>


### PR DESCRIPTION
This is a follow-up to 452ecbf1628e8299fd48154171ee152137e32d96. When the logic was inverted in ALPACA, it should have been inverter here too. Closes #361.