### PR TITLE
np.inf

### DIFF
--- a/ALPACA/ALPACA.py
+++ b/ALPACA/ALPACA.py
@@ -2497,7 +2497,7 @@ class ALPACALogic(ScriptedLoadableModuleLogic):
         maxAttempts = 1
         attempt = 0
         best_fitness = -1
-        best_rmse = np.Inf
+        best_rmse = np.inf
         while attempt < maxAttempts:
             # Perform Initial alignment using Ransac parallel iterations with no scaling
             transform_matrix, fitness, rmse = self.ransac_using_package(


### PR DESCRIPTION
Change 'Inf' to 'inf' due to AttributeError: np.Inf was removed in the NumPy 2.0 release. Use np.inf instead.