### PR TITLE
Add Claude Code Review workflow (automatic PR review)

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,0 +1,26 @@
+name: Claude Code Review
+
+# Automatically review every pull request with Claude (Max-subscription OAuth token).
+on:
+  pull_request:
+    types: [opened, synchronize]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: anthropics/claude-code-action@v1
+        with:
+          github_token: ${{ github.token }}
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          prompt: |
+            Review this pull request for correctness bugs, security issues,
+            edge cases, and regressions. Prefer a few high-confidence findings
+            over many speculative ones. Follow the conventions in CLAUDE.md if
+            present in the repository.


### PR DESCRIPTION
Adds `.github/workflows/claude-code-review.yml` so Claude reviews every pull request automatically (triggers on `pull_request`, uses `anthropics/claude-code-action@v1` with the `CLAUDE_CODE_OAUTH_TOKEN` secret already configured on this repo).

After merge, PRs into `master` get reviewed. (This PR isn't reviewed itself, since for `pull_request` GitHub runs the workflow from the base branch, which doesn't have it yet.)