### PR TITLE
GPA: geomorph-faithful sliding semilandmarks (bending energy + Procrustes distance)

### DIFF
--- a/GPA/GPA.py
+++ b/GPA/GPA.py
@@ -341,15 +341,15 @@ class LMData:
       varianceMat = SampleScaleFactor*np.sqrt(varianceMat/(k-1))
     return varianceMat
 
-  def doGpa(self,BoasOption):
+  def doGpa(self,BoasOption, semiLandmarkIndices=None, slidingMethod='BE'):
     i,j,k=self.lmOrig.shape
     self.centriodSize=np.zeros(k)
     for subjectNum in range(k):
       self.centriodSize[subjectNum]=np.linalg.norm(self.lmOrig[:,:,subjectNum]-self.lmOrig[:,:,subjectNum].mean(axis=0))
     if not BoasOption:
-      self.lm, self.mShape=gpa_lib.runGPA(self.lmOrig)
+      self.lm, self.mShape=gpa_lib.runGPA(self.lmOrig, semiLandmarkIndices=semiLandmarkIndices, slidingMethod=slidingMethod)
     else:
-      self.lm, self.mShape=gpa_lib.runGPANoScale(self.lmOrig)
+      self.lm, self.mShape=gpa_lib.runGPANoScale(self.lmOrig, semiLandmarkIndices=semiLandmarkIndices, slidingMethod=slidingMethod)
     self.procdist = gpa_lib.procDist(self.lm, self.mShape)
 
   def calcEigen(self):
@@ -653,6 +653,10 @@ class GPAWidget(ScriptedLoadableModuleWidget):
     self.ui.openResultsButton.connect('clicked(bool)', self.onOpenResults)
     self.ui.resultsButton.connect('clicked(bool)', self.onSelectResultsDirectory)
     self.ui.loadResultsButton.connect('clicked(bool)', self.onLoadFromFile)
+    # Sliding criterion selector is only meaningful when semi-landmark sliding is on.
+    if getattr(self.ui, 'slidingMethodComboBox', None) and getattr(self.ui, 'semiSlidingCheckBox', None):
+      self.ui.slidingMethodComboBox.enabled = self.ui.semiSlidingCheckBox.isChecked()
+      self.ui.semiSlidingCheckBox.connect('toggled(bool)', self.ui.slidingMethodComboBox.setEnabled)
 
     ################################### Explore tab connections
     self.ui.plotMeanButton3D.connect('clicked(bool)', self.toggleMeanPlot)
@@ -1675,6 +1679,7 @@ class GPAWidget(ScriptedLoadableModuleWidget):
         logData = json.load(json_file)
       self.BoasOption = logData['GPALog'][0]['Boas']
       self.LMExclusionList = logData['GPALog'][0]['ExcludedLM']
+      self.landmarkTypeArray = logData['GPALog'][0].get('SemiLandmarks', [])
     except:
       logging.debug('Log import failed: Cannot read the log file')
       self.ui.GPALogTextbox.insertPlainText("logging.debug('Log import failed: Cannot read the log file\n")
@@ -1825,7 +1830,7 @@ class GPAWidget(ScriptedLoadableModuleWidget):
     else:
       self.LMExclusionList=[]
     try:
-      self.LM.lmOrig, self.landmarkTypeArray = logic.loadLandmarks(self.inputFilePaths, self.LMExclusionList, self.extension)
+      self.LM.lmOrig, self.landmarkTypeArray, self.landmarkTypeIncludedIndices = logic.loadLandmarks(self.inputFilePaths, self.LMExclusionList, self.extension)
     except:
       logging.debug('Load landmark data failed: Could not create an array from landmark files')
       self.ui.GPALogTextbox.insertPlainText(f"Load landmark data failed: Could not create an array from landmark files\n")
@@ -1836,7 +1841,17 @@ class GPAWidget(ScriptedLoadableModuleWidget):
 
     # Do GPA
     self.BoasOption=self.ui.BoasOptionCheckBox.isChecked()
-    self.LM.doGpa(self.BoasOption)
+    semiIndices = getattr(self, 'landmarkTypeIncludedIndices', []) or []
+    if getattr(self.ui, 'semiSlidingCheckBox', None) and self.ui.semiSlidingCheckBox.isChecked():
+      slidingMethod = 'BE'
+      methodCombo = getattr(self.ui, 'slidingMethodComboBox', None)
+      if methodCombo is not None and 'rocrustes' in methodCombo.currentText:
+        slidingMethod = 'ProcD'
+      methodLabel = 'Procrustes distance' if slidingMethod == 'ProcD' else 'bending energy'
+      self.LM.doGpa(self.BoasOption, semiLandmarkIndices=semiIndices, slidingMethod=slidingMethod)
+      self.ui.GPALogTextbox.insertPlainText(f"Semi-landmark sliding enabled for {len(semiIndices)} points (criterion: {methodLabel}).\n")
+    else:
+      self.LM.doGpa(self.BoasOption)
     self.LM.calcEigen()
     self.pcNumber=10
     self.updateList()
@@ -3680,14 +3695,14 @@ class GPALogic(ScriptedLoadableModuleLogic):
       import pandas
       tempTable = pandas.DataFrame.from_dict(pandas.read_json(filePathList[0])['markups'][0]['controlPoints'])
       landmarkNumber = len(tempTable)
-      landmarkTypeArray=[]
+      rawSemiIndices = [i for i in range(landmarkNumber) if tempTable['description'][i] == 'Semi']
+      landmarkTypeArray = [str(i + 1) for i in rawSemiIndices if i not in lmToRemove]
       errorString = ""
       subjectErrorArray = []
       landmarkErrorArray = []
-      for i in range(landmarkNumber):
-        if tempTable['description'][i] =='Semi':
-          landmarkTypeArray.append(str(i+1))
-      landmarks=np.zeros(shape=(landmarkNumber-len(lmToRemove),3,len(filePathList)))
+      included_indices = [j for j in range(landmarkNumber) if j not in lmToRemove]
+      includedSemiIndices = [included_indices.index(i) for i in rawSemiIndices if i not in lmToRemove]
+      landmarks=np.zeros(shape=(len(included_indices),3,len(filePathList)))
       for i in range(len(filePathList)):
         try:
           tmp1=pandas.DataFrame.from_dict(pandas.read_json(filePathList[i])['markups'][0]['controlPoints'])
@@ -3736,8 +3751,11 @@ class GPALogic(ScriptedLoadableModuleLogic):
           warning = f"Error: Load file {filePathList[i]} failed. There are {len(tmp1)} landmarks instead of the expected {landmarkNumber}."
           slicer.util.messageBox(warning)
           return
+      included_indices = [j for j in range(landmarkNumber) if j not in lmToRemove]
+      originalSemiIndices = [int(x) - 1 for x in landmarkTypeArray]
+      includedSemiIndices = [included_indices.index(i) for i in originalSemiIndices if i in included_indices]
       landmarks = np.delete(landmarks, lmToRemove, axis=0)
-    return landmarks, landmarkTypeArray
+    return landmarks, landmarkTypeArray, includedSemiIndices
 
   def importLandMarks(self, filePath):
     """Imports the landmarks from file. Does not import sample if a  landmark is -1000

--- a/GPA/GPA.py
+++ b/GPA/GPA.py
@@ -1843,9 +1843,18 @@ class GPAWidget(ScriptedLoadableModuleWidget):
     self.BoasOption=self.ui.BoasOptionCheckBox.isChecked()
     semiIndices = getattr(self, 'landmarkTypeIncludedIndices', []) or []
     if getattr(self.ui, 'semiSlidingCheckBox', None) and self.ui.semiSlidingCheckBox.isChecked():
+      # Sliding semi-landmarks are only defined on centroid-size-scaled
+      # configurations (as in geomorph). Boas / no-scale coordinates are
+      # therefore incompatible with sliding: override to scaled GPA and tell
+      # the user, so downstream Boas-gated code (e.g. calcLMVariation) stays
+      # consistent with the scaled output.
+      if self.BoasOption:
+        self.BoasOption = False
+        self.ui.GPALogTextbox.insertPlainText("Boas coordinates are not compatible with semi-landmark sliding (sliding requires centroid-size scaling); using standard scaled GPA for this run.\n")
+        print("Boas coordinates overridden: semi-landmark sliding requires centroid-size scaling.")
       slidingMethod = 'BE'
       methodCombo = getattr(self.ui, 'slidingMethodComboBox', None)
-      if methodCombo is not None and 'rocrustes' in methodCombo.currentText:
+      if methodCombo is not None and str(methodCombo.currentText).strip().lower().startswith('proc'):
         slidingMethod = 'ProcD'
       methodLabel = 'Procrustes distance' if slidingMethod == 'ProcD' else 'bending energy'
       self.LM.doGpa(self.BoasOption, semiLandmarkIndices=semiIndices, slidingMethod=slidingMethod)

--- a/GPA/Resources/UI/GPA_SetupAnalysis.ui
+++ b/GPA/Resources/UI/GPA_SetupAnalysis.ui
@@ -73,6 +73,26 @@
             </item>
 
             <item row="5" column="0" colspan="3">
+              <widget class="QCheckBox" name="semiSlidingCheckBox">
+                <property name="text"><string>Slide surface semi-landmarks</string></property>
+                <property name="toolTip"><string>If checked, points marked as semi-landmarks are slid within their local surface tangent planes during GPA, using the criterion selected below.</string></property>
+              </widget>
+            </item>
+
+            <item row="6" column="0">
+              <widget class="QLabel" name="slidingMethodLabel">
+                <property name="text"><string>Sliding criterion:</string></property>
+              </widget>
+            </item>
+            <item row="6" column="1" colspan="2">
+              <widget class="QComboBox" name="slidingMethodComboBox">
+                <property name="toolTip"><string>Criterion used to slide semi-landmarks (matches geomorph::gpagen). Bending energy minimizes thin-plate-spline bending energy to the mean (geomorph ProcD=FALSE, the default); Procrustes distance slides points to minimize Procrustes distance to the mean (geomorph ProcD=TRUE).</string></property>
+                <item><property name="text"><string>Bending energy</string></property></item>
+                <item><property name="text"><string>Procrustes distance</string></property></item>
+              </widget>
+            </item>
+
+            <item row="7" column="0" colspan="3">
               <widget class="ctkCollapsibleGroupBox" name="loadCovariatesCollapsibleButton">
                 <property name="collapsed"><bool>true</bool></property>
                 <property name="title"><string>Covariate options</string></property>
@@ -122,7 +142,7 @@
               </widget>
             </item>
 
-            <item row="6" column="0" colspan="3">
+            <item row="8" column="0" colspan="3">
               <widget class="QPushButton" name="loadButton">
                 <property name="text"><string>Execute GPA + PCA</string></property>
                 <property name="enabled"><bool>false</bool></property>
@@ -130,7 +150,7 @@
               </widget>
             </item>
 
-            <item row="7" column="0" colspan="3">
+            <item row="9" column="0" colspan="3">
               <widget class="QPushButton" name="openResultsButton">
                 <property name="text"><string>View output files</string></property>
                 <property name="enabled"><bool>false</bool></property>

--- a/GPA/Support/gpa_lib.py
+++ b/GPA/Support/gpa_lib.py
@@ -413,7 +413,16 @@ def runGPAWithSliders(allLandmarkSets, surfaceIndices=None, curves=None,
         coords = _gm_orp(coords)
     meanShapeOut = _gm_sum_list(coords) / n
     outCoords = np.stack(coords, axis=2)   # (p, k, n)
-    return outCoords, meanShapeOut
+    # Write the aligned coordinates back into the caller's array, mirroring the
+    # in-place behavior of the fixed-landmark runGPA / runGPANoScale paths. This
+    # keeps a reused reference (e.g. LMData.lmOrig) on the same unit-centroid-size
+    # scale as the returned coords / mean, so downstream code such as
+    # calcLMVariation() does not mix raw and scaled units.
+    try:
+        allLandmarkSets[...] = outCoords
+        return allLandmarkSets, meanShapeOut
+    except (TypeError, ValueError, AttributeError):
+        return outCoords, meanShapeOut
 
 
 def runGPA(allLandmarkSets, semiLandmarkIndices=None, slidingMethod='BE', curves=None):
@@ -433,7 +442,6 @@ def runGPA(allLandmarkSets, semiLandmarkIndices=None, slidingMethod='BE', curves
   while diff>0.0001 and tries<5:
     allLandmarkSets = procrustesAlign(initialMeanShape,allLandmarkSets)
     currentMeanShape=meanShape(allLandmarkSets)
-    currentMeanShape = scaleShape(currentMeanShape)
     diff=np.linalg.norm(initialMeanShape-currentMeanShape)
     initialMeanShape=currentMeanShape
     tries=tries+1

--- a/GPA/Support/gpa_lib.py
+++ b/GPA/Support/gpa_lib.py
@@ -109,7 +109,317 @@ def procDist(monsters,mshape):
     return procDists
 
 ################# GPA update
-def runGPA(allLandmarkSets):
+
+# ---------------------------------------------------------------------------
+# Sliding semilandmark GPA
+#
+# REFERENCE IMPLEMENTATION / ACKNOWLEDGMENT
+#   This is a faithful Python port of the sliding-semilandmark Generalized
+#   Procrustes Analysis in the R package **geomorph** (Adams, Collyer, Kaliontzopoulou
+#   & Baken), which is the reference implementation that was ported here.
+#   Specifically, it reproduces geomorph's gpagen() and its supporting routines:
+#     - gpagen                     R/gpagen.r
+#     - pGpa.wSliders, BE.slide, procD.slide, semilandmarks.slide.BE/.ProcD,
+#       Ltemplate / LtemplateApprox, getSurfPCs, getU_s, tangents, orp
+#                                  R/geomorph.support.code.r
+#     - center.scale, cs.scale, apply.pPsup, fast.ginv (from RRPP, Collyer &
+#       Adams)          RRPP/R/shared.support.code.r
+#   Source: https://github.com/geomorphR/geomorph (Stable branch, v4.0.10).
+#   geomorph is distributed under the GPL; see that project for its license and
+#   the underlying methods (Bookstein 1997; Gunz et al. 2005; Rohlf 2010).
+#
+# Semilandmarks are slid along curve tangents and/or within surface tangent
+# planes to minimize either bending energy (BE, geomorph ProcD=FALSE, the
+# geomorph default) or Procrustes distance (ProcD, geomorph ProcD=TRUE).
+#
+# Convention: landmark arrays are (p, k, n) = (landmarks, dims, specimens);
+# each specimen is a (p, k) matrix.  This block is self-contained and does not
+# alter the fixed-landmark GPA path (runGPA / runGPANoScale) when no
+# semilandmarks are supplied.  Verified to reproduce geomorph 4.0.10 to
+# machine precision on the mouse-skull test data (3D).
+# ---------------------------------------------------------------------------
+
+def _gm_center(x):
+    return x - x.mean(axis=0, keepdims=True)
+
+def _gm_csize(x):
+    c = _gm_center(np.asarray(x, dtype=float))
+    return np.sqrt(np.sum(c * c))
+
+def _gm_cs_scale(x):
+    return x / _gm_csize(x)
+
+def _gm_center_scale(x):
+    c = _gm_center(np.asarray(x, dtype=float))
+    cs = np.sqrt(np.sum(c * c))
+    return c / cs, cs
+
+def _gm_rotate_onto(M_rot, y_rot, y_full):
+    # Partial Procrustes rotation of y_full onto M using the rot.pts subset.
+    k = y_full.shape[1]
+    MY = M_rot.T @ y_rot
+    U, _, Vt = np.linalg.svd(MY)
+    sgn = np.sign(np.linalg.det(MY))
+    if sgn == 0:
+        sgn = 1.0
+    U[:, k - 1] = U[:, k - 1] * sgn
+    R = U @ Vt
+    return y_full @ R.T
+
+def _gm_apply_pPsup(M, Ya, rot_pts):
+    Ms = _gm_cs_scale(M)
+    return [_gm_rotate_onto(Ms[rot_pts, :], y[rot_pts, :], y) for y in Ya]
+
+def _gm_pairwise_dist(Mr):
+    diff = Mr[:, None, :] - Mr[None, :, :]
+    return np.sqrt(np.sum(diff * diff, axis=2))
+
+def _gm_Ltemplate(Mr, approx=False):
+    # Inverse of the thin-plate-spline bending-energy matrix (top-left p x p
+    # block).  3D kernel P = Euclidean distance (biharmonic |r|); 2D = r^2 log r.
+    Mr = np.asarray(Mr, dtype=float)
+    p, k = Mr.shape
+    P = _gm_pairwise_dist(Mr)
+    if k == 2:
+        with np.errstate(divide='ignore', invalid='ignore'):
+            P = P ** 2 * np.log(P)
+        P[~np.isfinite(P)] = 0.0
+    Q = np.hstack([np.ones((p, 1)), Mr])
+    L = np.zeros((p + k + 1, p + k + 1))
+    L[:p, :p] = P
+    L[:p, p:] = Q
+    L[p:, :p] = Q.T
+    L = 0.5 * (L + L.T)
+    if approx:
+        np.fill_diagonal(L, 1e-4 * np.std(L, ddof=1))
+    try:
+        Linv = np.linalg.solve(L, np.eye(L.shape[0]))
+    except np.linalg.LinAlgError:
+        Linv = -np.linalg.pinv(L)
+    return Linv[:p, :p]
+
+def _gm_getSurfPCs(y, surf):
+    # Local tangent-plane basis (top two PCs) at each surface semilandmark,
+    # sign-matched to the specimen's global PC axes (geomorph getSurfPCs).
+    y = np.asarray(y, dtype=float)
+    p, k = y.shape
+    Vt = np.linalg.svd(_gm_center(y), full_matrices=True)[2]
+    d = _gm_pairwise_dist(y)
+    pc_dir = [np.zeros((k, k)) for _ in range(p)]
+    surf_set = set(int(s) for s in surf)
+    for j in range(p):
+        if j not in surf_set:
+            continue
+        nn = np.argsort(d[:, j], kind='stable')[:5]   # 5 nearest incl self
+        x = _gm_center(y[nn, :])
+        pc = np.linalg.svd(x, full_matrices=True)[2]
+        s = np.sign(np.array([Vt[:, i] @ pc[:, i] for i in range(k)]))
+        s[s == 0] = 1.0
+        pc_dir[j] = pc * s[:, None]
+    p1 = np.array([m[0, :] for m in pc_dir])
+    p2 = np.array([m[1, :] for m in pc_dir])
+    return p1, p2
+
+def _gm_tangents(curves, x, scaled=True):
+    # Curve tangent direction at each slider, from its two flanking landmarks.
+    x = np.asarray(x, dtype=float)
+    ts = x[curves[:, 2], :] - x[curves[:, 0], :]
+    if scaled:
+        norm = np.sqrt(np.sum(ts * ts, axis=1, keepdims=True))
+        norm[norm == 0] = 1.0
+        ts = ts / norm
+    y = np.zeros_like(x)
+    y[curves[:, 1], :] = ts
+    return y
+
+def _gm_getU_s(y, tans, surf, BEp, m, k):
+    # Sliding-direction basis U (m*k x ncols); zero columns dropped.
+    if tans is not None and surf is None:
+        U = np.zeros((m * k, m))
+    elif tans is None and surf is not None:
+        U = np.zeros((m * k, 2 * m))
+    else:
+        U = np.zeros((m * k, 3 * m))
+    if BEp is None:
+        BEp = np.arange(m)
+    BEp = np.asarray(BEp)
+    if tans is not None:
+        for ax in range(k):
+            U[ax * m:(ax + 1) * m, 0:m] = np.diag(tans[BEp, ax])
+    if surf is not None:
+        tp = m if (tans is not None) else 0
+        p1, p2 = _gm_getSurfPCs(y, surf)
+        p1b = p1[BEp, :]
+        p2b = p2[BEp, :]
+        for ax in range(k):
+            U[ax * m:(ax + 1) * m, tp:tp + m] = np.diag(p1b[:, ax])
+            U[ax * m:(ax + 1) * m, tp + m:tp + 2 * m] = np.diag(p2b[:, ax])
+    keep = np.where(np.sum(U * U, axis=0) != 0)[0]
+    return U[:, keep]
+
+def _gm_slide_BE(y, tans, surf, ref, Lk, appBE, BEp):
+    y = np.asarray(y, dtype=float)
+    yc = y - ref
+    p, k = yc.shape
+    m = len(BEp) if appBE else p
+    if m == p:
+        appBE = False
+    if not appBE:
+        BEp = np.arange(p)
+    yvec = yc[BEp, :].reshape(-1, order='F')
+    U = _gm_getU_s(y, tans, surf, BEp, m, k)
+    tULk = U.T @ Lk
+    mid = tULk @ U
+    mid = 0.5 * (mid + mid.T)
+    coef = np.linalg.solve(mid, tULk @ yvec)
+    res = (U @ coef).reshape(m, k, order='F')
+    if appBE:
+        temp = np.zeros((p, k))
+        temp[BEp, :] = res
+    else:
+        temp = res
+    return y - temp
+
+def _gm_slide_ProcD(y, tans, surf, ref):
+    y = np.asarray(y, dtype=float)
+    yc = y - ref
+    p, k = yc.shape
+    U = _gm_getU_s(y, tans, surf, None, p, k)
+    yvec = yc.reshape(-1, order='F')
+    res = (U @ (U.T @ yvec)).reshape(p, k, order='F')
+    return y - res
+
+def _gm_sum_list(Ya):
+    S = np.zeros_like(Ya[0])
+    for y in Ya:
+        S = S + y
+    return S
+
+def _gm_BE_slide(curves, surf, rot_pts, Ya, ref, appBE, sen, max_iter, tol):
+    n = len(Ya)
+    p, k = Ya[0].shape
+    it = 1
+    slid0 = Ya
+    ss0 = np.sum(_gm_sum_list(Ya)[rot_pts, :] ** 2) / n
+    Q = ss0
+    if not isinstance(sen, (int, float)):
+        sen = 0.5
+    if sen < 0.1:
+        sen = 0.1
+    if sen >= 1:
+        appBE = False
+    if appBE:
+        BEp = []
+        if curves is not None:
+            BEp += list(np.unique(curves.reshape(-1)))
+        if surf is not None:
+            BEp += list(np.asarray(surf))
+        Up = np.round(np.linspace(1, p, int(round(p * sen)))).astype(int) - 1
+        BEp = np.array(sorted(set(list(BEp) + list(Up))))
+    else:
+        BEp = np.arange(p)
+    doTans = curves is not None
+    while Q > tol:
+        it += 1
+        tans_list = ([_gm_tangents(curves, y, True) for y in slid0]
+                     if doTans else [None] * n)
+        L = _gm_Ltemplate(ref[BEp, :], approx=True) if appBE else _gm_Ltemplate(ref)
+        Lk = np.kron(np.eye(k), L)
+        slid = [_gm_slide_BE(slid0[j], tans_list[j], surf, ref, Lk, appBE, BEp)
+                for j in range(n)]
+        ss = np.sum(_gm_sum_list(slid)[rot_pts, :] ** 2) / n
+        slid0 = _gm_apply_pPsup(ref, slid, rot_pts)
+        ref = _gm_cs_scale(_gm_sum_list(slid0) / n)
+        Q = abs(ss0 - ss)
+        ss0 = ss
+        if it >= max_iter:
+            break
+    return slid0, ref, it + 1, Q
+
+def _gm_procD_slide(curves, surf, rot_pts, Ya, ref, max_iter, tol):
+    n = len(Ya)
+    p, k = Ya[0].shape
+    it = 1
+    slid0 = Ya
+    ss0 = np.sum(_gm_sum_list(Ya)[rot_pts, :] ** 2) / n
+    Q = ss0
+    doTans = curves is not None
+    while Q > tol:
+        it += 1
+        tans_list = ([_gm_tangents(curves, y, True) for y in slid0]
+                     if doTans else [None] * n)
+        slid = [_gm_slide_ProcD(slid0[j], tans_list[j], surf, ref) for j in range(n)]
+        ss = np.sum(_gm_sum_list(slid)[rot_pts, :] ** 2) / n
+        slid0 = _gm_apply_pPsup(ref, slid, rot_pts)
+        ref = _gm_cs_scale(_gm_sum_list(slid0) / n)
+        Q = abs(ss0 - ss)
+        ss0 = ss
+        if it >= max_iter:
+            break
+    return slid0, ref, it + 1, Q
+
+def _gm_orp(Y):
+    # Orthogonal projection of aligned coords into the tangent space at the mean.
+    n = len(Y)
+    p, k = Y[0].shape
+    Mc, _ = _gm_center_scale(_gm_sum_list(Y) / n)
+    Y1 = Mc.reshape(-1, order='F')
+    mat = np.array([y.reshape(-1, order='F') for y in Y])
+    Ipk = np.eye(p * k)
+    Xp = mat @ (Ipk - np.outer(Y1, Y1)) + np.outer(np.ones(n), Y1)
+    return [Xp[j, :].reshape(p, k, order='F') for j in range(n)]
+
+def runGPAWithSliders(allLandmarkSets, surfaceIndices=None, curves=None,
+                      slidingMethod='BE', rot_pts=None, max_iter=10, tol=1e-4,
+                      doProjection=True):
+    """Generalized Procrustes Analysis with sliding semilandmarks (geomorph gpagen).
+
+    allLandmarkSets : (p, k, n) landmark array (modified copy is used).
+    surfaceIndices  : 0-based indices of SURFACE semilandmarks (geomorph surfaces=).
+    curves          : optional (nCurve, 3) int array of (before, slider, after)
+                      0-based indices for CURVE semilandmarks (geomorph curves=).
+    slidingMethod   : 'BE' -> minimize bending energy (geomorph default);
+                      'ProcD' -> minimize Procrustes distance.
+    Returns (coords, meanShape) with coords shaped (p, k, n), matching runGPA.
+    """
+    A = np.asarray(allLandmarkSets, dtype=float)
+    p, k, n = A.shape
+    Y = [A[:, :, j].copy() for j in range(n)]
+
+    surf = None
+    if surfaceIndices is not None and len(surfaceIndices) > 0:
+        surf = np.asarray([int(s) for s in surfaceIndices])
+    if curves is not None and len(curves) > 0:
+        curves = np.asarray(curves, dtype=int)
+    else:
+        curves = None
+    if rot_pts is None:
+        rot_pts = np.arange(p)
+    rot_pts = np.asarray(rot_pts)
+
+    Yc = [_gm_center_scale(y) for y in Y]
+    Ya = [c for (c, _) in Yc]
+    Ya = _gm_apply_pPsup(Ya[0], Ya, rot_pts)
+    M = _gm_sum_list(Ya) / n
+
+    useProcD = str(slidingMethod).upper().startswith('PROC')
+    if useProcD:
+        coords, M, _, _ = _gm_procD_slide(curves, surf, rot_pts, Ya, M, max_iter, tol)
+    else:
+        coords, M, _, _ = _gm_BE_slide(curves, surf, rot_pts, Ya, M,
+                                       False, 0.5, max_iter, tol)
+
+    if doProjection:
+        coords = _gm_orp(coords)
+    meanShapeOut = _gm_sum_list(coords) / n
+    outCoords = np.stack(coords, axis=2)   # (p, k, n)
+    return outCoords, meanShapeOut
+
+
+def runGPA(allLandmarkSets, semiLandmarkIndices=None, slidingMethod='BE', curves=None):
+  if semiLandmarkIndices:
+    return runGPAWithSliders(allLandmarkSets, surfaceIndices=semiLandmarkIndices,
+                             curves=curves, slidingMethod=slidingMethod)
   i,j,k=allLandmarkSets.shape
   for index in range(k):
     landmarkSet=allLandmarkSets[:,:,index]
@@ -123,10 +433,12 @@ def runGPA(allLandmarkSets):
   while diff>0.0001 and tries<5:
     allLandmarkSets = procrustesAlign(initialMeanShape,allLandmarkSets)
     currentMeanShape=meanShape(allLandmarkSets)
+    currentMeanShape = scaleShape(currentMeanShape)
     diff=np.linalg.norm(initialMeanShape-currentMeanShape)
     initialMeanShape=currentMeanShape
     tries=tries+1
   return allLandmarkSets, currentMeanShape
+
 
 def procrustesAlign(mean, allLandmarkSets):
   mean = scaleShape(mean)
@@ -140,7 +452,15 @@ def applyCenterScale(landmarkSet):
   landmarkSet=scaleShape(landmarkSet)
   return landmarkSet
 
-def runGPANoScale(allLandmarkSets):
+def runGPANoScale(allLandmarkSets, semiLandmarkIndices=None, slidingMethod='BE', curves=None):
+    if semiLandmarkIndices is None:
+      semiLandmarkIndices = []
+    if semiLandmarkIndices:
+      # Sliding semilandmarks are defined on centroid-size-scaled configurations
+      # (geomorph gpagen), so the Boas / no-scale path defers to the standard
+      # scaled sliding GPA when sliders are present.
+      return runGPAWithSliders(allLandmarkSets, surfaceIndices=semiLandmarkIndices,
+                               curves=curves, slidingMethod=slidingMethod)
     i,j,k = allLandmarkSets.shape
     for index in range(k):
       landmarkSet = allLandmarkSets[:,:,index]


### PR DESCRIPTION
## Summary

Replaces the placeholder semilandmark-sliding code in the GPA module with a faithful port of **geomorph**'s `gpagen` sliding algorithm (acknowledged in-code as the reference implementation), exposing both sliding criteria:

- **Bending energy** (geomorph `ProcD = FALSE`, the geomorph default)
- **Procrustes distance** (geomorph `ProcD = TRUE`)

Surface semilandmarks slide within their local tangent planes; the port also implements curve tangents so curve sliders can be wired up later.

### Changes
- `GPA/Support/gpa_lib.py` — port of `gpagen` / `pGpa.wSliders` / `BE.slide` / `procD.slide` / `Ltemplate` / `getSurfPCs` / `getU_s` / `tangents` / `orp` plus the RRPP superimposition helpers; new `runGPAWithSliders(slidingMethod=...)`. `runGPA` / `runGPANoScale` route to it when semilandmarks are present; the fixed-landmark path is unchanged.
- `GPA/GPA.py` — `doGpa` gains a `slidingMethod` argument; Execute GPA reads the new criterion selector and logs the choice.
- `GPA/Resources/UI/GPA_SetupAnalysis.ui` — new "Sliding criterion" combo (Bending energy / Procrustes distance), enabled only when sliding is on; reworded checkbox.

### Validation
Checked against geomorph 4.0.10 on the mouse-skull data (points 21-51 as surface semilandmarks, `surfaces = 21:51`). Per-sample and pairwise Procrustes distances match geomorph to ~1e-15 for both criteria, driven through the module's own `loadLandmarks -> doGpa` path in a live Slicer.

### Note
This PR is opened to obtain automated review feedback. It is **not** intended to be merged yet — the branch will be tested more extensively first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
