### PR TITLE
GPA: fix pre-existing pyupgrade lint failure in gpa_lib.py

### DIFF
--- a/GPA/Support/gpa_lib.py
+++ b/GPA/Support/gpa_lib.py
@@ -206,7 +206,7 @@ def _gm_getSurfPCs(y, surf):
     Vt = np.linalg.svd(_gm_center(y), full_matrices=True)[2]
     d = _gm_pairwise_dist(y)
     pc_dir = [np.zeros((k, k)) for _ in range(p)]
-    surf_set = set(int(s) for s in surf)
+    surf_set = {int(s) for s in surf}
     for j in range(p):
         if j not in surf_set:
             continue


### PR DESCRIPTION
## Summary

Fixes the pre-existing **pyupgrade** lint failure that has kept CI red on `slidingLMs` (independent of the semi/fixed-landmark feature in #467, which did not touch this file).

```diff
-    surf_set = set(int(s) for s in surf)
+    surf_set = {int(s) for s in surf}
```

Behavior-identical (set comprehension instead of `set(<generator>)`).

## How it was produced

Reproduced with the repo's pinned hook — `asottile/pyupgrade` **v3.19.1** with `--py39-plus` (per `.pre-commit-config.yaml`) — run on `GPA/Support/gpa_lib.py`. This was the only file the hook rewrote across the tree, so it should take the `Lint` job green.

Split out from #467 to keep that feature PR focused.
