### PR TITLE
ENH: MarkupEditor: add visibility actions for selected points

### DIFF
--- a/MarkupEditor/MarkupEditor.py
+++ b/MarkupEditor/MarkupEditor.py
@@ -89,6 +89,14 @@ class MarkupEditorSubjectHierarchyPlugin(AbstractScriptedSubjectHierarchyPlugin)
         self.selectAllPointsAction.objectName = 'SelectAllPointsAction'
         self.selectAllPointsAction.connect("triggered()", self.onSelectAllPointsAction)
 
+        self.toggleVisibilityPointsAction = qt.QAction(f"Toggle visibility of selected points", scriptedPlugin)
+        self.toggleVisibilityPointsAction.objectName = 'ToggleVisibilityPointsAction'
+        self.toggleVisibilityPointsAction.connect("triggered()", self.onToggleVisibilityPointsAction)
+
+        self.resetVisibilityPointsAction = qt.QAction(f"Reset visibility of all control points", scriptedPlugin)
+        self.resetVisibilityPointsAction.objectName = 'ResetVisibilityPointsAction'
+        self.resetVisibilityPointsAction.connect("triggered()", self.onResetVisibilityPointsAction)
+
         self.addToGridAction = qt.QAction(f"Add point to grid", scriptedPlugin)
         self.addToGridAction.objectName = 'AddToGridAction'
         self.addToGridAction.connect("triggered()", self.onAddToGridAction)
@@ -163,6 +171,19 @@ class MarkupEditorSubjectHierarchyPlugin(AbstractScriptedSubjectHierarchyPlugin)
         for index in range(fiducialsNode.GetNumberOfControlPoints()):
           fiducialsNode.SetNthControlPointSelected(index, True)
 
+    def onToggleVisibilityPointsAction(self):
+        fiducialsNode = self.fiducialNodeFromEvent
+        with slicer.util.NodeModify(fiducialsNode):
+          for index in range(fiducialsNode.GetNumberOfControlPoints()):
+            if fiducialsNode.GetNthControlPointSelected(index):
+              fiducialsNode.SetNthControlPointVisibility(index, not fiducialsNode.GetNthControlPointVisibility(index))
+
+    def onResetVisibilityPointsAction(self):
+        fiducialsNode = self.fiducialNodeFromEvent
+        with slicer.util.NodeModify(fiducialsNode):
+          for index in range(fiducialsNode.GetNumberOfControlPoints()):
+            fiducialsNode.SetNthControlPointVisibility(index, True)
+
     def onAddToGridAction(self):
         fiducialsNode = self.fiducialNodeFromEvent
         fiducialIndex = self.fiducialIndexFromEvent
@@ -184,7 +205,7 @@ class MarkupEditorSubjectHierarchyPlugin(AbstractScriptedSubjectHierarchyPlugin)
     def viewContextMenuActions(self):
         #return [self.selectViewAction, self.editViewAction, self.deleteViewAction, self.addToGridAction]
         return [self.selectViewAction, self.editViewAction, self.deleteViewAction, self.toggleSelectedPointsAction,
-        self.selectAllPointsAction, self.addToGridAction]
+        self.selectAllPointsAction, self.toggleVisibilityPointsAction, self.resetVisibilityPointsAction, self.addToGridAction]
 
     def showViewContextMenuActionsForItem(self, itemID, eventData=None):
         pluginHandlerSingleton = slicer.qSlicerSubjectHierarchyPluginHandler.instance()
@@ -205,6 +226,8 @@ class MarkupEditorSubjectHierarchyPlugin(AbstractScriptedSubjectHierarchyPlugin)
             menuActions.append('DeleteViewAction')
             menuActions.append('ToggleSelectedPointsAction')
             menuActions.append('SelectAllPointsAction')
+            menuActions.append('ToggleVisibilityPointsAction')
+            menuActions.append('ResetVisibilityPointsAction')
             menuActions.append('AddToGridAction')
             if int(slicer.app.revision)>=30033:
               pluginLogic.setAllowedViewContextMenuActionNamesForItem(itemID, menuActions)
@@ -215,6 +238,8 @@ class MarkupEditorSubjectHierarchyPlugin(AbstractScriptedSubjectHierarchyPlugin)
             self.deleteViewAction.visible = True
             self.toggleSelectedPointsAction.visible = True
             self.selectAllPointsAction.visible = True
+            self.toggleVisibilityPointsAction.visible = True
+            self.resetVisibilityPointsAction.visible = True
             self.addToGridAction.visible = True
             self.viewNodeFromEvent = viewNode
             self.fiducialNodeFromEvent = associatedNode


### PR DESCRIPTION
## Problem

Per-control-point visibility can only be changed one point at a time via the eye icons in the Markups control points table. MarkupEditor's lasso workflow ("Pick points with curve...") already handles group *selection*, but there is no way to hide/show that group, and no way to restore visibility of all points without clicking them back one by one.

## Solution

Two new actions in the 3D view right-click menu on fiducial points:

- **Toggle visibility of selected points** — flips visibility of every control point whose selection flag is set (e.g. the lassoed group); unselected points are untouched. Selection state survives hiding, so toggling twice restores the same group.
- **Reset visibility of all control points** — makes every point visible again in one click.

Both loops run inside `slicer.util.NodeModify` so the node emits a single update instead of one event per point (noticeable with dense semilandmark sets).

## Testing

Verified headlessly inside Slicer 5.11 (`--no-main-window --python-script`): with points 0-4 of 10 selected, toggle hides exactly those 5; second toggle restores them; reset restores all points and leaves selection flags unchanged. Also manually tested in the GUI via the lasso -> right-click workflow.

Known corner case (pre-existing pattern): if *all* points are hidden there is nothing left to right-click in the 3D view; recovery is via the Markups module toolbar eye button.

🤖 Generated with [Claude Code](https://claude.com/claude-code)