### PR TITLE
Add review-only @claude mention workflow (issues/PRs)

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -43,8 +43,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          # Read the dev branch, not the default (master) this workflow fires from.
-          ref: geomorphTab
+          # Issue/diagnosis runs read the dev branch (not the 'master' default this workflow
+          # fires from). PR-review mentions instead check out the PR's own head, so the review
+          # sees the PR's code rather than geomorphTab.
+          ref: ${{ (github.event_name == 'pull_request_review' || github.event_name == 'pull_request_review_comment') && github.event.pull_request.head.sha || 'geomorphTab' }}
           fetch-depth: 1
 
       - uses: anthropics/claude-code-action@v1

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,54 @@
+name: Claude
+
+# On-demand REVIEW / DESIGN responder for SlicerMorph: runs when a trusted user @-mentions
+# Claude in an issue or PR. It READS the code and posts review/design comments — it does NOT
+# implement changes (implementation + testing stay local). Two SlicerMorph specifics:
+#   * This file must live on the DEFAULT branch (master) for GitHub to fire it on issue events.
+#   * But development happens on geomorphTab, so the checkout below pulls `geomorphTab` — the
+#     diagnosis reflects the code that actually ships, not stale master. Update that ref if the
+#     dev branch changes.
+# Complements claude-code-review.yml, which auto-reviews every PR.
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  pull_request_review:
+    types: [submitted]
+  issues:
+    types: [opened, assigned]
+
+jobs:
+  claude:
+    # Gate on @claude mention AND a trusted author (OWNER/MEMBER/COLLABORATOR), so only
+    # people with repo access can trigger this paid job.
+    if: >
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude') && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude') && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude') && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.review.author_association)) ||
+      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')) && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.issue.author_association))
+    # Serialize runs per issue/PR.
+    concurrency:
+      group: claude-${{ github.event.issue.number || github.event.pull_request.number }}
+      cancel-in-progress: false
+    runs-on: ubuntu-latest
+    # Review-only: contents is read-only (no push), the job just posts comments.
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # Read the dev branch, not the default (master) this workflow fires from.
+          ref: geomorphTab
+          fetch-depth: 1
+
+      - uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          # Read + comment tools only. No Edit/Write/git: this responder critiques and
+          # suggests (in comments); it must not try to author/push changes on the runner.
+          claude_args: |
+            --allowedTools "Read,Grep,Glob,mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh issue view:*),Bash(gh issue comment:*)"

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -16,7 +16,9 @@ on:
   pull_request_review:
     types: [submitted]
   issues:
-    types: [opened, assigned]
+    # Only 'opened' (not 'assigned'): assignment can't target a GitHub App and would just
+    # re-fire the job on every reassignment of an issue whose body already contains @claude.
+    types: [opened]
 
 jobs:
   claude:


### PR DESCRIPTION
Enables handing SlicerMorph issues to `@claude` for **diagnosis / design review only** (e.g. #472). Review-only per our standing decision — it reads code and comments, never implements or pushes (implementation stays local).

Two SlicerMorph specifics:
- Lives on **`master`** (the default branch) because GitHub only fires issue-triggered workflows from the default branch.
- Its checkout points at **`geomorphTab`** (the dev branch per the ExtensionsIndex), so a diagnosis reflects the code that actually ships rather than stale `master`.

Hardened like the others: `author_association` trust gate, per-issue/PR `concurrency`. Complements `claude-code-review.yml` (unchanged). After merge, re-post `@claude ...` on an issue to trigger it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)