### PR TITLE
PERF: speed up MergeMarkups Batch Merge (mergeLMNodes O(n^2) -> O(n))

### DIFF
--- a/MergeMarkups/MergeMarkups.py
+++ b/MergeMarkups/MergeMarkups.py
@@ -435,25 +435,33 @@ class MergeMarkupsLogic(ScriptedLoadableModuleLogic):
     # if there are no landmark descriptions, these will be set according to the
     # fixed/semiLM box they were entered in
     mergedNode = slicer.mrmlScene.AddNewNodeByClass('vtkMRMLMarkupsFiducialNode')
-    for index in range(fixedLM.GetNumberOfControlPoints()):
-      pt = fixedLM.GetNthControlPointPositionVector(index)
-      fiducialLabel = fixedLM.GetNthControlPointLabel(index)
-      fiducialDescription = fixedLM.GetNthControlPointDescription(index)
-      if fiducialDescription == "":
-        fiducialDescription = "Fixed"
-      mergedNode.AddControlPoint(pt,fiducialLabel)
-      mergedNode.SetNthControlPointDescription(index,"Fixed")
+    # The node is in the scene with a display node, so each AddControlPoint would
+    # otherwise fire an event that rebuilds every glyph, making the loop O(n^2).
+    # StartModify/EndModify batches the additions into a single rebuild; try/finally
+    # guarantees events are re-enabled even if the loop raises.
+    wasModifying = mergedNode.StartModify()
+    try:
+      for index in range(fixedLM.GetNumberOfControlPoints()):
+        pt = fixedLM.GetNthControlPointPositionVector(index)
+        fiducialLabel = fixedLM.GetNthControlPointLabel(index)
+        fiducialDescription = fixedLM.GetNthControlPointDescription(index)
+        if fiducialDescription == "":
+          fiducialDescription = "Fixed"
+        mergedNode.AddControlPoint(pt,fiducialLabel)
+        mergedNode.SetNthControlPointDescription(index,"Fixed")
 
-    for index in range(semiLM.GetNumberOfControlPoints()):
-      pt = semiLM.GetNthControlPointPositionVector(index)
-      fiducialLabel = semiLM.GetNthControlPointLabel(index)
-      fiducialDescription = semiLM.GetNthControlPointDescription(index)
-      mergedNode.AddControlPoint(pt,fiducialLabel)
-      mergedIndex = mergedNode.GetNumberOfControlPoints()-1
-      if fiducialDescription == "":
-        mergedNode.SetNthControlPointDescription(mergedIndex,"Semi")
-      else:
-        mergedNode.SetNthControlPointDescription(mergedIndex,fiducialDescription)
+      for index in range(semiLM.GetNumberOfControlPoints()):
+        pt = semiLM.GetNthControlPointPositionVector(index)
+        fiducialLabel = semiLM.GetNthControlPointLabel(index)
+        fiducialDescription = semiLM.GetNthControlPointDescription(index)
+        mergedNode.AddControlPoint(pt,fiducialLabel)
+        mergedIndex = mergedNode.GetNumberOfControlPoints()-1
+        if fiducialDescription == "":
+          mergedNode.SetNthControlPointDescription(mergedIndex,"Semi")
+        else:
+          mergedNode.SetNthControlPointDescription(mergedIndex,fiducialDescription)
+    finally:
+      mergedNode.EndModify(wasModifying)
     return mergedNode
 
   def runApplyLandmarksType(self, markupsTreeView, label):


### PR DESCRIPTION
Fixes #472.

### Problem
The **Batch Merge** tab builds each merged node point-by-point via `mergeLMNodes`, on a node that is added to `slicer.mrmlScene` and therefore displayed. Every `AddControlPoint` fires an event that rebuilds the glyph representation for *all* points added so far, so the loop is **O(n²)** — ~30 s per subject for 1000 semi + 51 fixed landmarks.

### Fix
Wrap the two point-adding loops in `mergedNode.StartModify()` / `mergedNode.EndModify(wasModifying)` so the display pipeline rebuilds **once** instead of per point, collapsing the loop to O(n). A `try/finally` guarantees events are re-enabled even if the loop raises (otherwise the node would be left with events permanently disabled). No other change: `loadMarkups`/`saveNode` and the scene add/remove lifecycle are untouched.

This is the established Slicer batching pattern, already used in-repo on a live displayed node at `MorphPreferences/Resources/SlicerMorphRC.py`.

### Verification
- Byte-identical output confirmed against the original implementation on a synthetic 51-fixed + 1000-semi case (positions, labels, and descriptions all match; first 51 = "Fixed", empty semi descriptions → "Semi", non-empty preserved).
- `StartModify`/`EndModify` only gates event *notification*, not the underlying control-point mutations, so merged data is identical.
- Expected runtime: ~30 s → sub-second per subject (the ~150× seen previously with this pattern on a related merge). Perf is display-driven, so it is not observable in a headless run.

Diagnosis and design discussion: #472.

🤖 Generated with [Claude Code](https://claude.com/claude-code)