### PR TITLE
Stop middle-button drag from translating whole markup nodes

### DIFF
--- a/MorphPreferences/Resources/SlicerMorphRC.py
+++ b/MorphPreferences/Resources/SlicerMorphRC.py
@@ -261,7 +261,9 @@ def onLayoutChangedDisableMiddleDrag(layoutId):
 
 disableMarkupMiddleButtonDrag()
 slicer.mrmlScene.AddObserver(slicer.vtkMRMLScene.NodeAddedEvent, onNodeAddedDisableMiddleDrag)
-slicer.app.layoutManager().connect("layoutChanged(int)", onLayoutChangedDisableMiddleDrag)
+layoutManager = slicer.app.layoutManager()
+if layoutManager is not None:
+    layoutManager.connect("layoutChanged(int)", onLayoutChangedDisableMiddleDrag)
 
 logging.info("Done customizing with SlicerMorphRC.py")
 logging.info("On first load of customization, restart Slicer to take effect.")

--- a/MorphPreferences/Resources/SlicerMorphRC.py
+++ b/MorphPreferences/Resources/SlicerMorphRC.py
@@ -239,14 +239,29 @@ def disableMarkupMiddleButtonDrag():
             if widget:
                 widget.SetEventTranslation(onWidget, middleButtonPress, noModifier, noAction)
 
-def onMarkupNodeAddedDisableMiddleDrag(caller, event):
-    # A markup's widget is created on the next render, not at NodeAddedEvent time,
-    # so re-apply after short delays to catch the newly created widget.
+def scheduleDisableMarkupMiddleButtonDrag():
+    # A markups widget is created by its view's displayable manager on the next
+    # render -- when a markup is added, or when a new view/layout is created --
+    # not synchronously with the triggering event, so re-apply after short delays
+    # to catch the newly created widget.
     for delayMs in (0, 200, 500):
         qt.QTimer.singleShot(delayMs, disableMarkupMiddleButtonDrag)
 
+@vtk.calldata_type(vtk.VTK_OBJECT)
+def onNodeAddedDisableMiddleDrag(caller, event, calldata):
+    # Only react to markups nodes (and their display nodes); skip the many
+    # non-markup nodes in a typical specimen scene.
+    if isinstance(calldata, (slicer.vtkMRMLMarkupsNode, slicer.vtkMRMLMarkupsDisplayNode)):
+        scheduleDisableMarkupMiddleButtonDrag()
+
+def onLayoutChangedDisableMiddleDrag(layoutId):
+    # A layout change creates fresh views whose markups widgets start with the
+    # default mapping, so re-apply even when no markup node was added.
+    scheduleDisableMarkupMiddleButtonDrag()
+
 disableMarkupMiddleButtonDrag()
-slicer.mrmlScene.AddObserver(slicer.vtkMRMLScene.NodeAddedEvent, onMarkupNodeAddedDisableMiddleDrag)
+slicer.mrmlScene.AddObserver(slicer.vtkMRMLScene.NodeAddedEvent, onNodeAddedDisableMiddleDrag)
+slicer.app.layoutManager().connect("layoutChanged(int)", onLayoutChangedDisableMiddleDrag)
 
 logging.info("Done customizing with SlicerMorphRC.py")
 logging.info("On first load of customization, restart Slicer to take effect.")

--- a/MorphPreferences/Resources/SlicerMorphRC.py
+++ b/MorphPreferences/Resources/SlicerMorphRC.py
@@ -208,6 +208,46 @@ toolBar.addAction(qt.QIcon(":/Icons/Medium/SlicerUndo.png"), "Undo", onUndo)
 toolBar.addAction(qt.QIcon(":/Icons/Medium/SlicerRedo.png"), "Redo", onRedo)
 slicer.util.mainWindow().addToolBar(toolBar)
 
+#
+# Prevent a middle-button drag over a markup from translating the whole node.
+# By default the markups widget maps a middle-button press while the cursor is
+# over a markup (WidgetStateOnWidget) to a whole-widget translate, so an
+# ordinary camera/slice pan that happens to start on a landmark drags every
+# control point instead. Remapping that event to "no action" on each markups
+# widget lets the middle button fall through to the normal camera/slice pan.
+# Left-click control-point editing, handles, and the context menu are unaffected.
+#
+def disableMarkupMiddleButtonDrag():
+    onWidget = slicer.vtkSlicerMarkupsWidget.WidgetStateOnWidget
+    noAction = slicer.vtkSlicerMarkupsWidget.WidgetEventNone
+    middleButtonPress = vtk.vtkCommand.MiddleButtonPressEvent
+    noModifier = vtk.vtkEvent.NoModifier
+    layoutManager = slicer.app.layoutManager()
+    if layoutManager is None:
+        return
+    views = [layoutManager.threeDWidget(i).threeDView()
+             for i in range(layoutManager.threeDViewCount)]
+    views += [layoutManager.sliceWidget(name).sliceView()
+              for name in layoutManager.sliceViewNames()]
+    displayNodes = slicer.util.getNodesByClass("vtkMRMLMarkupsDisplayNode")
+    for view in views:
+        manager = view.displayableManagerByClassName("vtkMRMLMarkupsDisplayableManager")
+        if not manager:
+            continue
+        for displayNode in displayNodes:
+            widget = manager.GetWidget(displayNode)
+            if widget:
+                widget.SetEventTranslation(onWidget, middleButtonPress, noModifier, noAction)
+
+def onMarkupNodeAddedDisableMiddleDrag(caller, event):
+    # A markup's widget is created on the next render, not at NodeAddedEvent time,
+    # so re-apply after short delays to catch the newly created widget.
+    for delayMs in (0, 200, 500):
+        qt.QTimer.singleShot(delayMs, disableMarkupMiddleButtonDrag)
+
+disableMarkupMiddleButtonDrag()
+slicer.mrmlScene.AddObserver(slicer.vtkMRMLScene.NodeAddedEvent, onMarkupNodeAddedDisableMiddleDrag)
+
 logging.info("Done customizing with SlicerMorphRC.py")
 logging.info("On first load of customization, restart Slicer to take effect.")
 


### PR DESCRIPTION
## Problem

In a 3D view a middle-button drag normally pans the camera. But if the drag *starts on a markup*, the markups widget grabs it and translates the **entire node** instead — every control point moves together. It is easy to trigger by accident while framing a view and awkward to undo, especially during landmarking.

The cause is in `vtkSlicerMarkupsWidget`: a middle-button press while the cursor is over a markup (`WidgetStateOnWidget`) is mapped to a whole-widget translate (`WidgetStateTranslate`). There is no display-node property that gates this, so the only clean lever is the event mapping itself.

## Fix

In the SlicerMorph customization file (`MorphPreferences/Resources/SlicerMorphRC.py`), remap that one event to "no action" (`WidgetEventNone`) on every markups widget. With no translation for the event, the widget reports it cannot process it and the middle button falls through to the normal camera / slice pan.

- Applies to existing markups in 3D and slice views.
- A `NodeAddedEvent` observer re-applies the remap (staggered `singleShot`s, since a markup's widget is created on the next render, not at node-added time) so markups created later in the session are covered.
- **Unaffected:** left-click control-point placement/editing, interaction handles (arrows/rings), and the right-click context menu. Only the middle-button whole-node grab is neutralized.

This is opt-in like the rest of `SlicerMorphRC.py` — it only runs when the user has enabled *Customize SlicerMorph ... at startup* in MorphPreferences.

## Verification

Tested live against a running Slicer over the MCP bridge by simulating a real middle-button drag directly on a control point (hover confirmed `ActiveComponentType == ControlPoint`, i.e. the drag genuinely hit the markup):

| | control point moved | camera moved |
|---|---|---|
| Slicer default mapping | 1.68 mm (whole node jumps) | - |
| after this change | **0.00 mm** | 1.68 mm (pans instead) |

The same drag that moved the whole node now leaves it fixed and pans the camera.

🤖 Generated with [Claude Code](https://claude.com/claude-code)