### PR TITLE
FastModelAlign: add the geodesic kernel option for the BCPD backend

### DIFF
--- a/FastModelAlign/FastModelAlign.py
+++ b/FastModelAlign/FastModelAlign.py
@@ -1103,6 +1103,25 @@ class FastModelAlignLogic(ScriptedLoadableModuleLogic):
         upper = np.max(pointsArray, axis=0)
         return (lower[0], upper[0], lower[1], upper[1], lower[2], upper[2])
 
+    @staticmethod
+    def medianNearestNeighborDistance(points):
+        """Median distance from each point to its nearest neighbour, or None.
+
+        The characteristic spacing of a point cloud. Both the displacement-grid
+        spacing and BCPD's geodesic graph radius are scaled to it rather than fixed,
+        so they follow the point density instead of assuming one. Returns None for
+        inputs where it is undefined (fewer than two points, or coincident points).
+        """
+        pointsArray = np.asarray(points, dtype=np.float64).reshape(-1, 3)
+        if len(pointsArray) < 2:
+            return None
+        from scipy.spatial import cKDTree
+        distances, _ = cKDTree(pointsArray).query(pointsArray, k=2)
+        spacing = float(np.median(distances[:, 1]))
+        if not np.isfinite(spacing) or spacing <= 0.0:
+            return None
+        return spacing
+
     def geodesicKernelArgument(self, controlPoints, parameters):
         """Build bcpd's -G geodesic-kernel argument for this point cloud.
 
@@ -1113,17 +1132,11 @@ class FastModelAlignLogic(ScriptedLoadableModuleLogic):
         """
         tau = float(parameters.get("GeodesicTau", 0.2))
         tau = min(max(tau, 0.01), 1.0)
-        pointsArray = np.asarray(controlPoints, dtype=np.float64).reshape(-1, 3)
-        radius = 1.0
-        if len(pointsArray) > 1:
-            from scipy.spatial import cKDTree
-            distances, _ = cKDTree(pointsArray).query(pointsArray, k=2)
-            spacing = float(np.median(distances[:, 1]))
-            if np.isfinite(spacing) and spacing > 0.0:
-                radius = spacing * self.BCPD_GEODESIC_RADIUS_FACTOR
+        spacing = self.medianNearestNeighborDistance(controlPoints)
+        radius = 1.0 if spacing is None else spacing * self.BCPD_GEODESIC_RADIUS_FACTOR
         argument = f"-Ggeo,{tau:g},{self.BCPD_GEODESIC_NEIGHBOURS:d},{radius:g}"
         logging.info(f"FastModelAlign: geodesic kernel {argument} "
-                     f"(control-point spacing {radius / self.BCPD_GEODESIC_RADIUS_FACTOR:.3f})")
+                     f"(control-point spacing {spacing if spacing is not None else float('nan'):.3f})")
         return argument
 
     def recommendGridSpacing(self, controlPoints):
@@ -1138,15 +1151,11 @@ class FastModelAlignLogic(ScriptedLoadableModuleLogic):
 
         See GRID_SPACING_FRACTION_OF_CONTROL_SPACING for the measured basis.
         """
-        pointsArray = np.asarray(controlPoints, dtype=np.float64).reshape(-1, 3)
-        if len(pointsArray) < 2:
-            return 1.0
-        from scipy.spatial import cKDTree
-        distances, _ = cKDTree(pointsArray).query(pointsArray, k=2)
-        controlSpacing = float(np.median(distances[:, 1]))
-        if not np.isfinite(controlSpacing) or controlSpacing <= 0.0:
+        controlSpacing = self.medianNearestNeighborDistance(controlPoints)
+        if controlSpacing is None:
             logging.warning("FastModelAlign: degenerate control-point spacing, using 1 mm grid")
             return 1.0
+        pointsArray = np.asarray(controlPoints, dtype=np.float64).reshape(-1, 3)
         spacing = controlSpacing * self.GRID_SPACING_FRACTION_OF_CONTROL_SPACING
         logging.info(f"FastModelAlign: control-point spacing {controlSpacing:.3f} mm (median "
                      f"nearest neighbour of {len(pointsArray)} points) -> automatic grid "

--- a/FastModelAlign/FastModelAlign.py
+++ b/FastModelAlign/FastModelAlign.py
@@ -33,9 +33,26 @@ class FastModelAlign(ScriptedLoadableModule):
         self.parent.contributors = ["Chi Zhang (SCRI), Murat Maga (UW)"]  # TODO: replace with "Firstname Lastname (Organization)"
         # TODO: update with short description of the module and a link to online module documentation
         self.parent.helpText = """This module uses ALPACA libraries to do rigid and affine transforms of 3D Models quickly via pointcloud registration.
-See the usage tutorial at <a href="https://github.com/SlicerMorph/Tutorials/tree/master/FastModelAlign">module documentation</a>."""
+See the usage tutorial at <a href="https://github.com/SlicerMorph/Tutorials/tree/master/FastModelAlign">module documentation</a>.
+<p>The deformable step can optionally be accelerated with <a href="https://github.com/ohirose/bcpd">BCPD</a>
+(Bayesian Coherent Point Drift) by Osamu Hirose, which also provides the geodesic
+kernel. BCPD is a separate program that you install yourself; point the module at
+it under Advanced Settings. Please cite the papers listed in the acknowledgements
+if you use it."""
         # TODO: replace with organization, grant and thanks
-        self.parent.acknowledgementText = """The development of the module was supported by NSF/OAC grant, HDR Institute: Imageomics: A New Frontier of Biological Information Powered by Knowledge-Guided Machine Learnings" (Award #2118240)."""
+        self.parent.acknowledgementText = """The development of the module was supported by NSF/OAC grant, HDR Institute: Imageomics: A New Frontier of Biological Information Powered by Knowledge-Guided Machine Learnings" (Award #2118240).
+<p>The optional accelerated deformable registration is performed by
+<a href="https://github.com/ohirose/bcpd">BCPD</a>, written by Osamu Hirose and
+distributed under the MIT license (Copyright (c) 2019-2023 Osamu Hirose). BCPD is
+not bundled with this module; it is installed separately by the user. If you use
+it, please cite:
+<ul>
+<li>O. Hirose, "A Bayesian formulation of coherent point drift," IEEE TPAMI, Feb 2020.</li>
+<li>O. Hirose, "Acceleration of non-rigid point set registration with downsampling
+and Gaussian process regression," IEEE TPAMI, Dec 2020.</li>
+<li>O. Hirose, "Geodesic-Based Bayesian Coherent Point Drift," IEEE TPAMI, Oct 2022
+(used when the geodesic kernel is enabled).</li>
+</ul>"""
 
         # Additional initialization step after application startup is complete
         slicer.app.connect("startupCompleted()", registerSampleData)
@@ -868,6 +885,11 @@ class FastModelAlignLogic(ScriptedLoadableModuleLogic):
     # same mapping ALPACA uses. The rest are the values validated on real specimen
     # data; in particular BCPD's own convergence settings (-n/-c) are used rather
     # than the CPD iteration/tolerance sliders, which only drive the cpdalp path.
+    # BCPD (Bayesian Coherent Point Drift) is an external program by Osamu Hirose,
+    # MIT licensed, https://github.com/ohirose/bcpd - not bundled here, the user
+    # installs it and points the module at it. See the module acknowledgements for
+    # the papers to cite: BCPD (TPAMI 2020), the downsampling/GP acceleration used
+    # by -A (TPAMI 2020), and GBCPD for the geodesic kernel (TPAMI 2022).
     BCPD_FIXED_ARGUMENTS = ["-w0.1", "-g0.1", "-ux", "-n200", "-c1e-6", "-A"]
 
     # Geodesic kernel (GBCPD). The Gaussian kernel measures distance through space,

--- a/FastModelAlign/FastModelAlign.py
+++ b/FastModelAlign/FastModelAlign.py
@@ -168,6 +168,8 @@ class FastModelAlignWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
         # BCPD acceleration of the deformable step (optional external binary)
         self.ui.accelerationCheckBox.connect("toggled(bool)", self.onAccelerationToggled)
         self.ui.BCPDFolder.connect("validInputChanged(bool)", self.onChangeBCPDPath)
+        self.ui.geodesicKernelCheckBox.connect("toggled(bool)", self.onGeodesicKernelToggled)
+        self.ui.geodesicTauSlider.connect("valueChanged(double)", self.onChangeAdvanced)
 
         # Restore the persisted BCPD path (shared with ALPACA) and acceleration state.
         savedBCPDPath = self.logic.getBCPDPath()
@@ -193,6 +195,8 @@ class FastModelAlignWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
             "gridSpacing": self.ui.gridSpacingSlider.value,
             "gridSpacingAuto": self.ui.gridSpacingAutoCheckBox.checked,
             "Acceleration": self.ui.accelerationCheckBox.checked,
+            "GeodesicKernel": self.ui.geodesicKernelCheckBox.checked,
+            "GeodesicTau": self.ui.geodesicTauSlider.value,
             "BCPDFolder": self.ui.BCPDFolder.currentPath,
             }
 
@@ -242,7 +246,20 @@ class FastModelAlignWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
     def onAccelerationToggled(self, checked):
         """Enable/disable the BCPD path entry and persist the checkbox state."""
         self.ui.BCPDFolder.enabled = bool(checked)
+        # The geodesic kernel is a BCPD feature; cpdalp has only a Gaussian kernel,
+        # so it cannot be offered on the built-in path.
+        self.ui.geodesicKernelCheckBox.enabled = bool(checked)
+        if not checked:
+            self.ui.geodesicKernelCheckBox.checked = False
+        self.onGeodesicKernelToggled(self.ui.geodesicKernelCheckBox.checked)
         self.logic.saveAccelerationEnabled(bool(checked))
+        self.updateParameterDictionary()
+
+    def onGeodesicKernelToggled(self, checked):
+        """Tau only means anything while the geodesic kernel is in use."""
+        usable = bool(checked) and self.ui.accelerationCheckBox.checked
+        self.ui.geodesicTauSlider.enabled = usable
+        self.ui.geodesicTauLabel.enabled = usable
         self.updateParameterDictionary()
 
     def onChangeBCPDPath(self):
@@ -267,6 +284,8 @@ class FastModelAlignWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
             self.parameterDictionary["gridSpacing"] = self.ui.gridSpacingSlider.value
             self.parameterDictionary["gridSpacingAuto"] = self.ui.gridSpacingAutoCheckBox.checked
             self.parameterDictionary["Acceleration"] = self.ui.accelerationCheckBox.checked
+            self.parameterDictionary["GeodesicKernel"] = self.ui.geodesicKernelCheckBox.checked
+            self.parameterDictionary["GeodesicTau"] = self.ui.geodesicTauSlider.value
             self.parameterDictionary["BCPDFolder"] = self.ui.BCPDFolder.currentPath
 
 
@@ -851,6 +870,21 @@ class FastModelAlignLogic(ScriptedLoadableModuleLogic):
     # than the CPD iteration/tolerance sliders, which only drive the cpdalp path.
     BCPD_FIXED_ARGUMENTS = ["-w0.1", "-g0.1", "-ux", "-n200", "-c1e-6", "-A"]
 
+    # Geodesic kernel (GBCPD). The Gaussian kernel measures distance through space,
+    # so a thin structure lying beside a larger one is coupled to it and gets dragged
+    # along instead of deforming on its own: on a mouse -> tree shrew pair the
+    # deformable step left the zygomatic arches 2.31 mm short of the target, worse
+    # than the 1.74 mm they were at before it ran. Measuring along the surface
+    # decouples them - the same pair reached 1.05 mm at tau 0.2.
+    #
+    # bcpd builds the surface graph itself from the point cloud
+    # (-G'geo,<tau>,<neighbours>,<radius>'), so no mesh has to be supplied. The
+    # radius is derived from the control-point spacing rather than fixed, for the
+    # same reason the grid spacing is: a constant in normalized units is only right
+    # for one point density.
+    BCPD_GEODESIC_NEIGHBOURS = 8
+    BCPD_GEODESIC_RADIUS_FACTOR = 2.0
+
     # The registration runs on the main thread, so a wedged external binary would
     # otherwise hang the application with no way to cancel. Timing out raises, and
     # the caller treats any BCPD failure as a signal to fall back to cpdalp.
@@ -1009,6 +1043,8 @@ class FastModelAlignLogic(ScriptedLoadableModuleLogic):
                         f"-l{float(parameters['alpha']):g}",
                         f"-b{float(parameters['beta']):g}"]
                        + list(self.BCPD_FIXED_ARGUMENTS))
+            if parameters.get("GeodesicKernel", False):
+                command.append(self.geodesicKernelArgument(sourceNorm, parameters))
             logging.info("FastModelAlign: running " + " ".join(command))
             try:
                 completed = subprocess.run(command, check=True, text=True,
@@ -1044,6 +1080,29 @@ class FastModelAlignLogic(ScriptedLoadableModuleLogic):
         lower = np.min(pointsArray, axis=0)
         upper = np.max(pointsArray, axis=0)
         return (lower[0], upper[0], lower[1], upper[1], lower[2], upper[2])
+
+    def geodesicKernelArgument(self, controlPoints, parameters):
+        """Build bcpd's -G geodesic-kernel argument for this point cloud.
+
+        The neighbour radius is scaled to the control-point spacing so the surface
+        graph connects neighbours regardless of how densely the clouds were
+        subsampled; a fixed radius would silently disconnect the graph at low point
+        density and over-connect at high density.
+        """
+        tau = float(parameters.get("GeodesicTau", 0.2))
+        tau = min(max(tau, 0.01), 1.0)
+        pointsArray = np.asarray(controlPoints, dtype=np.float64).reshape(-1, 3)
+        radius = 1.0
+        if len(pointsArray) > 1:
+            from scipy.spatial import cKDTree
+            distances, _ = cKDTree(pointsArray).query(pointsArray, k=2)
+            spacing = float(np.median(distances[:, 1]))
+            if np.isfinite(spacing) and spacing > 0.0:
+                radius = spacing * self.BCPD_GEODESIC_RADIUS_FACTOR
+        argument = f"-Ggeo,{tau:g},{self.BCPD_GEODESIC_NEIGHBOURS:d},{radius:g}"
+        logging.info(f"FastModelAlign: geodesic kernel {argument} "
+                     f"(control-point spacing {radius / self.BCPD_GEODESIC_RADIUS_FACTOR:.3f})")
+        return argument
 
     def recommendGridSpacing(self, controlPoints):
         """Grid spacing implied by the control-point distribution, in millimeters.

--- a/FastModelAlign/Resources/UI/FastModelAlign.ui
+++ b/FastModelAlign/Resources/UI/FastModelAlign.ui
@@ -803,7 +803,7 @@
              <bool>false</bool>
             </property>
             <property name="toolTip">
-             <string>Select the directory containing the compiled BCPD executable. This setting is shared with ALPACA, so it only has to be set once.</string>
+             <string>Select the directory containing the compiled BCPD executable. BCPD (Bayesian Coherent Point Drift) is a separate MIT-licensed program by Osamu Hirose, https://github.com/ohirose/bcpd - it is not bundled with SlicerMorph and you install it yourself. This setting is shared with ALPACA, so it only has to be set once.</string>
             </property>
             <property name="filters">
              <set>ctkPathLineEdit::Dirs</set>
@@ -823,7 +823,7 @@
              <bool>false</bool>
             </property>
             <property name="toolTip">
-             <string>Measure distance along the surface instead of through space when smoothing the deformation (GBCPD). The Gaussian kernel couples points that are close in space, so a thin structure lying beside a larger one - a zygomatic arch beside the braincase - is dragged along with its neighbour rather than deforming independently. The geodesic kernel treats them as far apart because the path between them runs along the surface. Only available with BCPD acceleration; the built-in cpdalp backend has no geodesic kernel.</string>
+             <string>Measure distance along the surface instead of through space when smoothing the deformation (GBCPD). The Gaussian kernel couples points that are close in space, so a thin structure lying beside a larger one - a zygomatic arch beside the braincase - is dragged along with its neighbour rather than deforming independently. The geodesic kernel treats them as far apart because the path between them runs along the surface. Only available with BCPD acceleration; the built-in cpdalp backend has no geodesic kernel. Implements GBCPD (Hirose, IEEE TPAMI 2022); please cite it if you use this option.</string>
             </property>
             <property name="text">
              <string>Use geodesic kernel (GBCPD)</string>

--- a/FastModelAlign/Resources/UI/FastModelAlign.ui
+++ b/FastModelAlign/Resources/UI/FastModelAlign.ui
@@ -810,6 +810,64 @@
             </property>
            </widget>
           </item>
+          <item row="2" column="0">
+           <widget class="QLabel" name="geodesicKernelLabel">
+            <property name="text">
+             <string>Kernel:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="1">
+           <widget class="QCheckBox" name="geodesicKernelCheckBox">
+            <property name="enabled">
+             <bool>false</bool>
+            </property>
+            <property name="toolTip">
+             <string>Measure distance along the surface instead of through space when smoothing the deformation (GBCPD). The Gaussian kernel couples points that are close in space, so a thin structure lying beside a larger one - a zygomatic arch beside the braincase - is dragged along with its neighbour rather than deforming independently. The geodesic kernel treats them as far apart because the path between them runs along the surface. Only available with BCPD acceleration; the built-in cpdalp backend has no geodesic kernel.</string>
+            </property>
+            <property name="text">
+             <string>Use geodesic kernel (GBCPD)</string>
+            </property>
+            <property name="checked">
+             <bool>false</bool>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="0">
+           <widget class="QLabel" name="geodesicTauLabel">
+            <property name="enabled">
+             <bool>false</bool>
+            </property>
+            <property name="text">
+             <string>Tau (geodesic weight):</string>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="1">
+           <widget class="ctkSliderWidget" name="geodesicTauSlider">
+            <property name="enabled">
+             <bool>false</bool>
+            </property>
+            <property name="toolTip">
+             <string>Balance between the geodesic and Gaussian kernels. Lower values weight the geodesic more, which lets thin structures deform independently of what they lie beside; 1.0 is effectively the plain Gaussian kernel. On a mouse-to-tree-shrew pair the zygomatic deficit fell from 2.31 mm at 1.0 to about 1.05 mm at 0.2, with values between 0.1 and 0.3 indistinguishable from each other.</string>
+            </property>
+            <property name="decimals">
+             <number>2</number>
+            </property>
+            <property name="singleStep">
+             <double>0.050000000000000</double>
+            </property>
+            <property name="minimum">
+             <double>0.010000000000000</double>
+            </property>
+            <property name="maximum">
+             <double>1.000000000000000</double>
+            </property>
+            <property name="value">
+             <double>0.200000000000000</double>
+            </property>
+           </widget>
+          </item>
          </layout>
         </widget>
        </item>


### PR DESCRIPTION
Stacked on #480 — review that first; this PR's diff is the geodesic work alone.

## What went wrong, which is not what it looked like

On a mouse → tree shrew pair the zygomatic arches came out visibly too narrow. The obvious reading is "not enough deformation", but measuring the lateral half-width profile says the opposite:

| A-P station | target | after rigid+scaling | after deformable |
|---|---|---|---|
| +5.5 | 12.34 | 11.17 | **10.37** |
| +8.7 | 11.88 | 10.35 | **9.84** |

The deformable step made the skull *narrower than it already was*, at 5 of 14 A-P stations. It spends the arches to buy fit across the braincase — and it does buy a lot (coverage 0.769 → 0.449 mm), so this is a real trade, not a bug.

The cause is the kernel. A Euclidean Gaussian couples points that are close **in space**; the arch lies beside the braincase, so it is dragged along with it. Where the target arch bows out past any source tissue, those points also find a closer, denser match on the braincase wall and go medial.

## Tuning does not fix it

Five fixed seeds per config (bcpd's Nyström sampling is randomised, so single runs are not comparable — an earlier single run of β=0.5 showed 1.20 mm and was a lucky draw):

| config | coverage | zygomatic deficit |
|---|---|---|
| λ=2 β=2 (default) | 0.326 ± 0.001 | 2.31 ± 0.06 |
| λ=2 β=1 | 0.259 ± 0.005 | 2.43 ± 0.04 |
| λ=2 β=0.5 | 0.292 ± 0.017 | 1.97 ± 0.25 |
| affine + deformable | 0.321 ± 0.000 | 2.49 ± 0.06 |
| rigid+scaling only | 0.553 | 1.74 |

Softer priors mostly widen the spread. Affine makes it worse — its singular values are 1.026 / 0.998 / **0.894**, so it compresses an axis rather than stretching laterally.

## The geodesic kernel does

| config | coverage | zygomatic deficit | width err, all stations |
|---|---|---|---|
| gaussian | 0.326 ± 0.001 | 2.31 ± 0.07 | 0.59 |
| geo τ=0.05 | 0.380 ± 0.009 | 1.29 ± 0.14 | 0.62 |
| **geo τ=0.2** | 0.374 ± 0.004 | **1.05 ± 0.20** | 0.59 |
| geo τ=0.5 | 0.372 ± 0.003 | 1.76 ± 0.26 | 0.76 |

More than halved, and now better than the pre-deformable state, so the step improves the arches instead of degrading them. Width error across all stations is unchanged at 0.59, so it is not robbing the rest of the skull. The cost is coverage: 0.326 → 0.374.

τ between 0.1 and 0.3 is within run-to-run noise, so the default is 0.2 and the slider is there for the cases where it matters.

## BCPD-only, by necessity

cpdalp has a single hard-coded Euclidean kernel and `DeformableRegistration.__init__` takes only `(alpha, beta, low_rank, num_eig)` — no kernel argument to swap. So the option is greyed out unless BCPD acceleration is selected, and turning acceleration off clears it so a stale selection cannot survive into a cpdalp run.

## Verified live in Slicer, 22/22

Widgets, the full gating chain (acceleration → geodesic → tau, and clearing on the way back down), the parameter dictionary, the `-G` argument including radius scaling and tau clamping, and an end-to-end pair of BCPD runs confirming the geodesic result actually differs (max 2.14).

## Caveat

One specimen pair, one metric. Worth checking against mouse → rat before considering any change of default — if it only helps the hard case and mildly hurts the easy one, it should stay an option, which is why it is off by default here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)