### PR TITLE
QuickAlign: bring the 4-view layout to geomorphTab, with fixes

### DIFF
--- a/QuickAlign/QuickAlign.py
+++ b/QuickAlign/QuickAlign.py
@@ -191,6 +191,10 @@ class QuickAlignWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
         Filtering is done by node ID through the combo box's sort/filter proxy model.
         Note that qMRMLNodeComboBox.baseName is *not* a filter -- it only supplies the
         default name for nodes created from the combo box -- so it cannot be used here.
+
+        hiddenNodeIDs must be assigned as a property: setHiddenNodeIDs() is a plain
+        public C++ method, neither a slot nor Q_INVOKABLE, so it is not callable
+        from Python.
         """
         node1 = self.ui.inputSelector1.currentNode()
         node2 = self.ui.inputSelector2.currentNode()
@@ -209,7 +213,7 @@ class QuickAlignWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
         for selector in [self.ui.landmarksSelector1, self.ui.landmarksSelector2]:
             proxyModel = selector.sortFilterProxyModel()
             if proxyModel:
-                proxyModel.setHiddenNodeIDs(sorted(excludeIDs))
+                proxyModel.hiddenNodeIDs = sorted(excludeIDs)
 
     def updateLandmarkDisplay(self):
         """Apply transforms and view restrictions to currently selected landmarks"""
@@ -239,7 +243,7 @@ class QuickAlignWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
         for selector in [self.ui.landmarksSelector1, self.ui.landmarksSelector2]:
             proxyModel = selector.sortFilterProxyModel()
             if proxyModel:
-                proxyModel.setHiddenNodeIDs([])
+                proxyModel.hiddenNodeIDs = []
 
     def hasFourViewNodes(self):
         """True when all four QuickAlign view nodes have been resolved."""
@@ -373,6 +377,13 @@ class QuickAlignWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
         if node2:
             self.setDisplayViewNodeIDs(node2.GetDisplayNode(), [self.viewNode2.GetID()])
 
+        # The scene has now been changed, so Unlink must be reachable from here on.
+        # Enable it before the optional landmark / joint editing work below, so that
+        # a failure there still leaves the user a way back to the original scene.
+        self.ui.unlinkButton.enabled = True
+        self.ui.linkButton.enabled = False
+        self.ui.initializeViewButton.enabled = False
+
         # Enable landmark selectors now that sync has started
         self.ui.landmarksSelector1.enabled = True
         self.ui.landmarksSelector2.enabled = True
@@ -390,8 +401,6 @@ class QuickAlignWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
 
         # If joint editing checkbox is enabled and checked, start joint editing
         if self.ui.jointEditCheckBox.enabled and self.ui.jointEditCheckBox.checked:
-            node1 = self.ui.inputSelector1.currentNode()
-            node2 = self.ui.inputSelector2.currentNode()
             landmarks1 = self.ui.landmarksSelector1.currentNode()
             landmarks2 = self.ui.landmarksSelector2.currentNode()
 
@@ -407,10 +416,7 @@ class QuickAlignWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
                         "Joint editing was not enabled: the two point lists must have "
                         "the same number of points.")
 
-        #set up for unlink action
-        self.ui.unlinkButton.enabled = True
-        self.ui.linkButton.enabled = False
-        self.ui.initializeViewButton.enabled = False
+        # The checkbox is locked in for the duration of the sync
         self.ui.jointEditCheckBox.enabled = False
 
     def onUnlinkButton(self):

--- a/QuickAlign/QuickAlign.py
+++ b/QuickAlign/QuickAlign.py
@@ -65,6 +65,11 @@ class QuickAlignWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
         # display state captured before the module took the scene over, so that
         # Unlink can put the scene back the way the user left it
         self._savedDisplayState = {}
+        # joint point list editing: the nodes the observers are actually attached
+        # to, so teardown never depends on what the selectors currently say
+        self.jointEditNodes = None
+        self.observerList = []
+        self._updatingJointEditing = False
 
         # Define custom layouts for module in slicer global namespace
         slicer.customLayoutQuickAlign = """
@@ -156,6 +161,7 @@ class QuickAlignWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
         self.ui.inputSelector2.connect('currentNodeChanged(vtkMRMLNode*)', self.onSelect)
         self.ui.landmarksSelector1.connect('currentNodeChanged(vtkMRMLNode*)', self.onLandmarkChanged)
         self.ui.landmarksSelector2.connect('currentNodeChanged(vtkMRMLNode*)', self.onLandmarkChanged)
+        self.ui.jointEditCheckBox.connect('toggled(bool)', self.onJointEditToggled)
         self.ui.initializeViewButton.connect('clicked(bool)', self.onInitializeViewButton)
         self.ui.linkButton.connect('clicked(bool)', self.onLinkButton)
         self.ui.unlinkButton.connect('clicked(bool)', self.onUnlinkButton)
@@ -184,6 +190,71 @@ class QuickAlignWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
 
         self.updateLandmarkDisplay()
         self.updateJointEditingAvailability()
+        # Landmarks can only be picked once the sync has started, so this is where
+        # joint editing on a landmark pair actually gets wired up.
+        self.updateJointEditing()
+
+    def onJointEditToggled(self, checked):
+        """Start or stop joint editing when the user toggles the check box."""
+        self.updateJointEditing()
+
+    def jointEditingNodes(self):
+        """The pair of point lists joint editing should operate on, or (None, None).
+
+        The aligned objects are preferred when they are themselves point lists;
+        otherwise their landmark sets are used.
+        """
+        node1 = self.ui.inputSelector1.currentNode()
+        node2 = self.ui.inputSelector2.currentNode()
+        landmarks1 = self.ui.landmarksSelector1.currentNode()
+        landmarks2 = self.ui.landmarksSelector2.currentNode()
+        editNode1 = node1 if self.isFiducialNode(node1) else landmarks1
+        editNode2 = node2 if self.isFiducialNode(node2) else landmarks2
+        if self.isFiducialNode(editNode1) and self.isFiducialNode(editNode2):
+            return editNode1, editNode2
+        return None, None
+
+    def updateJointEditing(self):
+        """Make the joint editing observers match the current selection.
+
+        Called whenever anything that feeds jointEditingNodes() changes, so that
+        picking landmarks after Link -- the only time they can be picked -- starts
+        joint editing, and swapping a selection re-targets it instead of leaving
+        observers on the old node.
+        """
+        if self._updatingJointEditing:
+            return
+        self._updatingJointEditing = True
+        try:
+            editNode1, editNode2 = self.jointEditingNodes()
+            wanted = bool(self.ui.jointEditCheckBox.enabled
+                          and self.ui.jointEditCheckBox.checked
+                          and editNode1 and editNode2)
+
+            # Tear down first if joint editing is running on the wrong pair
+            if self.jointEditNodes and (not wanted or self.jointEditNodes != (editNode1, editNode2)):
+                self.stopJointEditing()
+
+            if wanted and not self.jointEditNodes:
+                observerList = self.logic.startJointMarkupEditing(editNode1, editNode2)
+                if observerList:
+                    self.jointEditNodes = (editNode1, editNode2)
+                    self.observerList = observerList
+                else:
+                    self.ui.jointEditCheckBox.checked = False
+                    slicer.util.errorDisplay(
+                        "Joint editing was not enabled: the two point lists must have "
+                        "the same number of points.")
+        finally:
+            self._updatingJointEditing = False
+
+    def stopJointEditing(self):
+        """Detach joint editing from whichever nodes it was actually started on."""
+        if not self.jointEditNodes:
+            return
+        self.logic.endJointMarkupEditing(self.jointEditNodes[0], self.jointEditNodes[1], self.observerList)
+        self.jointEditNodes = None
+        self.observerList = []
 
     def filterLandmarkSelectors(self):
         """Hide Object 1 and Object 2 from the landmark selectors if they are markups.
@@ -269,11 +340,16 @@ class QuickAlignWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
         landmarksAreFiducials = self.isFiducialNode(landmarks1) and self.isFiducialNode(landmarks2)
 
         # Enable if either condition is true
-        self.ui.jointEditCheckBox.enabled = objectsAreFiducials or landmarksAreFiducials
+        available = objectsAreFiducials or landmarksAreFiducials
+        self.ui.jointEditCheckBox.enabled = available
 
-        # Auto-check if enabled and objects are fiducials (original behavior)
+        # Auto-check if enabled and objects are fiducials (original behavior).
+        # Clear it when joint editing is not available at all, so a stale checked
+        # state cannot outlive the selection that justified it.
         if objectsAreFiducials:
             self.ui.jointEditCheckBox.checked = True
+        elif not available:
+            self.ui.jointEditCheckBox.checked = False
 
     def onSelect(self):
         self.ui.initializeViewButton.enabled = bool(self.ui.inputSelector1.currentNode() and self.ui.inputSelector2.currentNode())
@@ -283,12 +359,18 @@ class QuickAlignWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
         node2 = self.ui.inputSelector2.currentNode()
         if node1 and node2:
             self.updateJointEditingAvailability()
+        # The object selectors stay live during a sync, so re-target (or drop)
+        # joint editing rather than leaving observers on the previous node.
+        self.updateJointEditing()
 
 
     def cleanup(self):
         """
         Called when the application closes and the module widget is destroyed.
         """
+        # Release the point lists before going away, otherwise they stay locked
+        # at a fixed control point count.
+        self.stopJointEditing()
         # The zoom sync observers are added directly on the camera nodes, so
         # VTKObservationMixin.removeObservers() does not know about them.
         self.removeZoomSyncObservers()
@@ -396,28 +478,12 @@ class QuickAlignWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
 
         self.update3DViews()
 
-        # Update joint editing availability after landmarks are applied
+        # Update joint editing availability after landmarks are applied, then start
+        # it if it applies. The check box stays live during the sync: landmarks can
+        # only be picked from here on, so joint editing on a landmark pair has to be
+        # able to start after Link (see updateJointEditing).
         self.updateJointEditingAvailability()
-
-        # If joint editing checkbox is enabled and checked, start joint editing
-        if self.ui.jointEditCheckBox.enabled and self.ui.jointEditCheckBox.checked:
-            landmarks1 = self.ui.landmarksSelector1.currentNode()
-            landmarks2 = self.ui.landmarksSelector2.currentNode()
-
-            # Prefer objects if they're fiducials, otherwise use landmarks
-            editNode1 = node1 if self.isFiducialNode(node1) else landmarks1
-            editNode2 = node2 if self.isFiducialNode(node2) else landmarks2
-
-            if editNode1 and editNode2:
-                self.observerList = self.logic.startJointMarkupEditing(editNode1, editNode2)
-                if self.observerList == []:
-                    self.ui.jointEditCheckBox.checked = False
-                    slicer.util.errorDisplay(
-                        "Joint editing was not enabled: the two point lists must have "
-                        "the same number of points.")
-
-        # The checkbox is locked in for the duration of the sync
-        self.ui.jointEditCheckBox.enabled = False
+        self.updateJointEditing()
 
     def onUnlinkButton(self):
         """
@@ -429,18 +495,9 @@ class QuickAlignWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
 
         node1 = self.ui.inputSelector1.currentNode()
         node2 = self.ui.inputSelector2.currentNode()
-        landmarks1 = self.ui.landmarksSelector1.currentNode()
-        landmarks2 = self.ui.landmarksSelector2.currentNode()
 
-        # End joint editing if it was initiated
-        if self.ui.jointEditCheckBox.checked and hasattr(self, 'observerList'):
-            # Determine which nodes were being edited
-            editNode1 = node1 if self.isFiducialNode(node1) else landmarks1
-            editNode2 = node2 if self.isFiducialNode(node2) else landmarks2
-
-            if editNode1 and editNode2:
-                self.logic.endJointMarkupEditing(editNode1, editNode2, self.observerList)
-            del self.observerList
+        # End joint editing, on whichever nodes it was actually started on
+        self.stopJointEditing()
 
         # Disable landmark selectors when not synced, and stop filtering them
         self.ui.landmarksSelector1.enabled = False
@@ -744,31 +801,39 @@ class QuickAlignWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
             cam.SetFocalPoint(0, 0, 0)
             cam.SetViewUp(viewUp[0], viewUp[1], viewUp[2])
             cam.OrthogonalizeViewUp()
-            # Reset the clipping range
+            # Reset the clipping range. threeDWidget() takes a widget index or a
+            # widget name -- passing the view node returns None, silently skipping
+            # the reset -- and the widget name matches the view node name.
             layoutManager = slicer.app.layoutManager()
-            threeDWidget = layoutManager.threeDWidget(viewNode)
+            threeDWidget = layoutManager.threeDWidget(viewNode.GetName())
             if threeDWidget:
                 threeDView = threeDWidget.threeDView()
                 threeDView.resetFocalPoint()
 
     # ---- Zoom synchronization helpers ----
     def setupZoomSyncPairs(self):
+      """Keep each specimen's superior and lateral view at the same zoom level.
+
+      Sync runs both ways within a pair; the _zoomSyncActive guard in
+      onZoomSourceModified stops the two observers from echoing each other.
+      """
       self.removeZoomSyncObservers()
       pairs = [
         (self.viewNode1, self.viewNode3),  # object 1 superior & side
         (self.viewNode2, self.viewNode4),  # object 2 superior & side
       ]
-      for sourceViewNode, targetViewNode in pairs:
-        sourceCamNode = slicer.modules.cameras.logic().GetViewActiveCameraNode(sourceViewNode)
-        targetCamNode = slicer.modules.cameras.logic().GetViewActiveCameraNode(targetViewNode)
-        if not sourceCamNode or not targetCamNode:
+      for superiorViewNode, lateralViewNode in pairs:
+        superiorCamNode = slicer.modules.cameras.logic().GetViewActiveCameraNode(superiorViewNode)
+        lateralCamNode = slicer.modules.cameras.logic().GetViewActiveCameraNode(lateralViewNode)
+        if not superiorCamNode or not lateralCamNode:
           continue
-        # Initial sync of zoom level
-        self.copyZoom(sourceCamNode, targetCamNode)
-        # Record mapping and add observer
-        self._zoomSourceToTarget[sourceCamNode.GetID()] = targetCamNode
-        tag = sourceCamNode.AddObserver(vtk.vtkCommand.ModifiedEvent, self.onZoomSourceModified)
-        self._zoomObserverTags.append((sourceCamNode, tag))
+        # Initial sync of zoom level, taking the superior view as the reference
+        self.copyZoom(superiorCamNode, lateralCamNode)
+        for sourceCamNode, targetCamNode in [(superiorCamNode, lateralCamNode),
+                                             (lateralCamNode, superiorCamNode)]:
+          self._zoomSourceToTarget[sourceCamNode.GetID()] = targetCamNode
+          tag = sourceCamNode.AddObserver(vtk.vtkCommand.ModifiedEvent, self.onZoomSourceModified)
+          self._zoomObserverTags.append((sourceCamNode, tag))
 
     def copyZoom(self, sourceCamNode, targetCamNode):
       srcCam = sourceCamNode.GetCamera()

--- a/QuickAlign/QuickAlign.py
+++ b/QuickAlign/QuickAlign.py
@@ -174,10 +174,14 @@ class QuickAlignWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
         self.ui.landmarksSelector1.enabled = False
         self.ui.landmarksSelector2.enabled = False
 
+    def isSynced(self):
+        """True between Link and Unlink, i.e. while the module is driving the scene."""
+        return bool(self.ui.unlinkButton.enabled)
+
     def onLandmarkChanged(self):
         """Called when landmark selection changes - update visibility and transforms immediately"""
-        # Only process if we're in synced state (the link button is disabled while synced)
-        if not hasattr(self, 'viewNode1') or self.ui.linkButton.enabled:
+        # Only process if we're in synced state
+        if not hasattr(self, 'viewNode1') or not self.isSynced():
             return
 
         # Validate that selected landmarks are not the same as objects
@@ -227,7 +231,12 @@ class QuickAlignWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
         self._updatingJointEditing = True
         try:
             editNode1, editNode2 = self.jointEditingNodes()
-            wanted = bool(self.ui.jointEditCheckBox.enabled
+            # Gated on the sync being active, so that merely picking two point lists
+            # in the object selectors never locks them or attaches observers before
+            # Link. The gate lives here rather than in each caller so no future call
+            # site can start joint editing outside a sync.
+            wanted = bool(self.isSynced()
+                          and self.ui.jointEditCheckBox.enabled
                           and self.ui.jointEditCheckBox.checked
                           and editNode1 and editNode2)
 
@@ -361,6 +370,7 @@ class QuickAlignWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
             self.updateJointEditingAvailability()
         # The object selectors stay live during a sync, so re-target (or drop)
         # joint editing rather than leaving observers on the previous node.
+        # updateJointEditing() is a no-op outside a sync.
         self.updateJointEditing()
 
 

--- a/QuickAlign/QuickAlign.py
+++ b/QuickAlign/QuickAlign.py
@@ -4,12 +4,20 @@ import os
 import vtk
 
 import slicer
-from slicer.ScriptedLoadableModule import *
+# Explicit imports to avoid linter/star import issues
+from slicer.ScriptedLoadableModule import (
+  ScriptedLoadableModule,
+  ScriptedLoadableModuleWidget,
+  ScriptedLoadableModuleLogic,
+)
 from slicer.util import VTKObservationMixin
 
-import math
 import numpy as np
 import scipy.linalg as sp
+
+# Layout IDs for QuickAlign custom layouts
+LAYOUT_ID_QUICKALIGN_2VIEW = 701
+LAYOUT_ID_QUICKALIGN_4VIEW = 702
 
 #
 # QuickAlign
@@ -50,6 +58,13 @@ class QuickAlignWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
         ScriptedLoadableModuleWidget.__init__(self, parent)
         VTKObservationMixin.__init__(self)  # needed for parameter node observation
         self.logic = None
+        # zoom sync bookkeeping
+        self._zoomSyncActive = False
+        self._zoomObserverTags = []
+        self._zoomSourceToTarget = {}
+        # display state captured before the module took the scene over, so that
+        # Unlink can put the scene back the way the user left it
+        self._savedDisplayState = {}
 
         # Define custom layouts for module in slicer global namespace
         slicer.customLayoutQuickAlign = """
@@ -62,8 +77,42 @@ class QuickAlignWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
                 </view>
                </item>
                <item>
-                <view class=\"vtkMRMLViewNode\" singletontag=\"2\" type=\"secondary\">"
-                 <property name=\"viewlabel\" action=\"default\">2</property>"
+                <view class=\"vtkMRMLViewNode\" singletontag=\"2\" type=\"secondary\">
+                 <property name=\"viewlabel\" action=\"default\">2</property>
+                </view>
+              </item>
+             </layout>
+           </item>
+          </layout>
+        """
+
+        # Define 2x2 layout with four 3D viewers
+        slicer.customLayoutQuickAlignLayout = """
+          <layout type=\"vertical\" split=\"true\">
+           <item splitSize=\"500\">
+             <layout type=\"horizontal\">
+               <item>
+                <view class=\"vtkMRMLViewNode\" singletontag=\"1\">
+                 <property name=\"viewlabel\" action=\"default\">1</property>
+                </view>
+               </item>
+               <item>
+                <view class=\"vtkMRMLViewNode\" singletontag=\"2\" type=\"secondary\">
+                 <property name=\"viewlabel\" action=\"default\">2</property>
+                </view>
+              </item>
+             </layout>
+           </item>
+           <item splitSize=\"500\">
+             <layout type=\"horizontal\">
+               <item>
+                <view class=\"vtkMRMLViewNode\" singletontag=\"3\" type=\"secondary\">
+                 <property name=\"viewlabel\" action=\"default\">3</property>
+                </view>
+               </item>
+               <item>
+                <view class=\"vtkMRMLViewNode\" singletontag=\"4\" type=\"secondary\">
+                 <property name=\"viewlabel\" action=\"default\">4</property>
                 </view>
               </item>
              </layout>
@@ -89,6 +138,8 @@ class QuickAlignWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
         uiWidget.setMRMLScene(slicer.mrmlScene)
         self.ui.inputSelector1.setMRMLScene(slicer.mrmlScene)
         self.ui.inputSelector2.setMRMLScene(slicer.mrmlScene)
+        self.ui.landmarksSelector1.setMRMLScene(slicer.mrmlScene)
+        self.ui.landmarksSelector2.setMRMLScene(slicer.mrmlScene)
 
         # Create logic class. Logic implements all computations that should be possible to run
         # in batch mode, without a graphical user interface.
@@ -103,26 +154,140 @@ class QuickAlignWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
         # Buttons
         self.ui.inputSelector1.connect('currentNodeChanged(vtkMRMLNode*)', self.onSelect)
         self.ui.inputSelector2.connect('currentNodeChanged(vtkMRMLNode*)', self.onSelect)
+        self.ui.landmarksSelector1.connect('currentNodeChanged(vtkMRMLNode*)', self.onLandmarkChanged)
+        self.ui.landmarksSelector2.connect('currentNodeChanged(vtkMRMLNode*)', self.onLandmarkChanged)
         self.ui.initializeViewButton.connect('clicked(bool)', self.onInitializeViewButton)
         self.ui.linkButton.connect('clicked(bool)', self.onLinkButton)
         self.ui.unlinkButton.connect('clicked(bool)', self.onUnlinkButton)
 
         # Custom Layout button
-        self.addLayoutButton(701, 'QuickAlign View', 'Custom layout for QuickAlign module', 'LayoutSlicerMorphView.png', slicer.customLayoutQuickAlign)
+        self.addLayoutButton(LAYOUT_ID_QUICKALIGN_2VIEW, 'QuickAlign View', 'Custom layout for QuickAlign module', 'LayoutSlicerMorphView.png', slicer.customLayoutQuickAlign)
+        self.addLayoutButton(LAYOUT_ID_QUICKALIGN_4VIEW, 'QuickAlignLayout', 'QuickAlign 2x2 layout with four 3D viewers', 'LayoutSlicerMorphView.png', slicer.customLayoutQuickAlignLayout)
+
+        # Initially disable landmark selectors until sync starts
+        self.ui.landmarksSelector1.enabled = False
+        self.ui.landmarksSelector2.enabled = False
+
+    def onLandmarkChanged(self):
+        """Called when landmark selection changes - update visibility and transforms immediately"""
+        # Only process if we're in synced state (the link button is disabled while synced)
+        if not hasattr(self, 'viewNode1') or self.ui.linkButton.enabled:
+            return
+
+        # Validate that selected landmarks are not the same as objects
+        if hasattr(self, 'excludedLandmarkIDs'):
+            for selector in [self.ui.landmarksSelector1, self.ui.landmarksSelector2]:
+                currentNode = selector.currentNode()
+                if currentNode and currentNode.GetID() in self.excludedLandmarkIDs:
+                    selector.setCurrentNode(None)
+                    slicer.util.warningDisplay(f"Cannot use {currentNode.GetName()} as a landmark - it is already selected as Object 1 or Object 2")
+
+        self.updateLandmarkDisplay()
+        self.updateJointEditingAvailability()
+
+    def filterLandmarkSelectors(self):
+        """Hide Object 1 and Object 2 from the landmark selectors if they are markups.
+
+        Filtering is done by node ID through the combo box's sort/filter proxy model.
+        Note that qMRMLNodeComboBox.baseName is *not* a filter -- it only supplies the
+        default name for nodes created from the combo box -- so it cannot be used here.
+        """
+        node1 = self.ui.inputSelector1.currentNode()
+        node2 = self.ui.inputSelector2.currentNode()
+
+        # Get IDs to exclude
+        excludeIDs = set()
+        if node1 and node1.IsA('vtkMRMLMarkupsNode'):
+            excludeIDs.add(node1.GetID())
+        if node2 and node2.IsA('vtkMRMLMarkupsNode'):
+            excludeIDs.add(node2.GetID())
+
+        # Store excluded IDs so onLandmarkChanged can validate a selection that
+        # was already in place before the filter was applied
+        self.excludedLandmarkIDs = excludeIDs
+
+        for selector in [self.ui.landmarksSelector1, self.ui.landmarksSelector2]:
+            proxyModel = selector.sortFilterProxyModel()
+            if proxyModel:
+                proxyModel.setHiddenNodeIDs(sorted(excludeIDs))
+
+    def updateLandmarkDisplay(self):
+        """Apply transforms and view restrictions to currently selected landmarks"""
+        if not (hasattr(self, 'centerNode1Transform') and hasattr(self, 'centerNode2Transform')):
+            return
+
+        landmarks1 = self.ui.landmarksSelector1.currentNode()
+        landmarks2 = self.ui.landmarksSelector2.currentNode()
+
+        # Update landmarks 1
+        if landmarks1:
+            landmarks1.SetAndObserveTransformNodeID(self.centerNode1Transform.GetID())
+            dn = landmarks1.GetDisplayNode()
+            self.setDisplayViewNodeIDs(dn, [self.viewNode1.GetID()])
+            self.setDisplayVisibility(dn, True)
+
+        # Update landmarks 2
+        if landmarks2:
+            landmarks2.SetAndObserveTransformNodeID(self.centerNode2Transform.GetID())
+            dn = landmarks2.GetDisplayNode()
+            self.setDisplayViewNodeIDs(dn, [self.viewNode2.GetID()])
+            self.setDisplayVisibility(dn, True)
+
+    def clearLandmarkSelectorFilter(self):
+        """Stop hiding nodes in the landmark selectors."""
+        self.excludedLandmarkIDs = set()
+        for selector in [self.ui.landmarksSelector1, self.ui.landmarksSelector2]:
+            proxyModel = selector.sortFilterProxyModel()
+            if proxyModel:
+                proxyModel.setHiddenNodeIDs([])
+
+    def hasFourViewNodes(self):
+        """True when all four QuickAlign view nodes have been resolved."""
+        return all(getattr(self, name, None) for name in
+                   ['viewNode1', 'viewNode2', 'viewNode3', 'viewNode4'])
+
+    @staticmethod
+    def isFiducialNode(node):
+        """True when node is a markups fiducial (point list) node."""
+        return node is not None and node.GetNodeTagName() == "MarkupsFiducial"
+
+    def updateJointEditingAvailability(self):
+        """Enable joint editing if either objects or landmarks are both fiducial markups"""
+        node1 = self.ui.inputSelector1.currentNode()
+        node2 = self.ui.inputSelector2.currentNode()
+        landmarks1 = self.ui.landmarksSelector1.currentNode()
+        landmarks2 = self.ui.landmarksSelector2.currentNode()
+
+        # Check if objects themselves are fiducials
+        objectsAreFiducials = self.isFiducialNode(node1) and self.isFiducialNode(node2)
+
+        # Check if landmarks are fiducials
+        landmarksAreFiducials = self.isFiducialNode(landmarks1) and self.isFiducialNode(landmarks2)
+
+        # Enable if either condition is true
+        self.ui.jointEditCheckBox.enabled = objectsAreFiducials or landmarksAreFiducials
+
+        # Auto-check if enabled and objects are fiducials (original behavior)
+        if objectsAreFiducials:
+            self.ui.jointEditCheckBox.checked = True
 
     def onSelect(self):
         self.ui.initializeViewButton.enabled = bool(self.ui.inputSelector1.currentNode() and self.ui.inputSelector2.currentNode())
-        #if nodes are markup fiducial lists, enable joint editing
+
+        # Update joint editing availability during selection phase
         node1 = self.ui.inputSelector1.currentNode()
         node2 = self.ui.inputSelector2.currentNode()
-        markupsTypeNodes = bool(node1.GetNodeTagName() == "MarkupsFiducial" and node2.GetNodeTagName() == "MarkupsFiducial")
-        self.ui.jointEditCheckBox.enabled = markupsTypeNodes
-        self.ui.jointEditCheckBox.checked = markupsTypeNodes
+        if node1 and node2:
+            self.updateJointEditingAvailability()
+
 
     def cleanup(self):
         """
         Called when the application closes and the module widget is destroyed.
         """
+        # The zoom sync observers are added directly on the camera nodes, so
+        # VTKObservationMixin.removeObservers() does not know about them.
+        self.removeZoomSyncObservers()
         self.removeObservers()
 
     def enter(self):
@@ -157,40 +322,90 @@ class QuickAlignWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
     def onLinkButton(self):
         """
         Run processing when user clicks "Link" button.
+        Links views 1 and 2 (superior views) while keeping side views 3 and 4 independent.
         """
-        if not (hasattr(self, 'viewNode1') and hasattr(self, 'viewNode2')):
-          print("Error: Can not find 2 3d views to link. Please reinitialize views.")
+        if not self.hasFourViewNodes():
+          slicer.util.errorDisplay("Can not find 4 3D views to link. Please reinitialize views.")
           return
+
+        # Get all cameras
         camera1 = slicer.modules.cameras.logic().GetViewActiveCameraNode(self.viewNode1)
         camera2 = slicer.modules.cameras.logic().GetViewActiveCameraNode(self.viewNode2)
 
-        #get zoom factor and set up scaling transform
+        # Calculate alignment between cameras 1 and 2 (the two superior views)
         camera2ZoomFactor = camera1.GetParallelScale()/camera2.GetParallelScale()
         scalingTransform=vtk.vtkTransform()
         scalingTransform.Scale(camera2ZoomFactor,camera2ZoomFactor,camera2ZoomFactor)
         self.scalingTransformNode = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLLinearTransformNode", "scale transform")
         self.scalingTransformNode.SetMatrixTransformToParent(scalingTransform.GetMatrix())
 
-        logic = QuickAlignLogic()
-        movingModel = self.ui.inputSelector2.currentNode()
+        # Get alignment transform between the two objects (cameras 1 and 2)
+        self.alignmentTransform = self.logic.getCameraAlignmentTransform(camera1, camera2)
 
-        #get alignment transform between cameras
-        self.alignmentTransform = logic.getCameraAlignmentTransform(camera1, camera2)
-        self.centerView2Transform.SetAndObserveTransformNodeID(self.alignmentTransform.GetID())
+        # Apply alignment to object 2 (shared transform used by both its view display nodes)
+        if hasattr(self, 'centerNode2Transform'):
+          self.centerNode2Transform.SetAndObserveTransformNodeID(self.alignmentTransform.GetID())
         self.alignmentTransform.SetAndObserveTransformNodeID(self.scalingTransformNode.GetID())
 
-        #link and update views
-        self.viewNode2.SetLinkedControl(True)
-        layoutManager = slicer.app.layoutManager()
-        self.update3DViews()
+        # Link views properly: SetLinkedControl must be True on the PRIMARY view
+        # All views start unlinked
+        self.viewNode1.SetLinkedControl(False)
+        self.viewNode2.SetLinkedControl(False)
+        self.viewNode3.SetLinkedControl(False)
+        self.viewNode4.SetLinkedControl(False)
 
-        #if nodes are markup fiducial lists, enable joint editing
+        # Now enable linking on view 1 - this will link ALL views together
+        self.viewNode1.SetLinkedControl(True)
+
+        # Switch to two-view layout (horizontal 1 & 2) per requirement
+        try:
+          layoutManager = slicer.app.layoutManager()
+          layoutManager.setLayout(LAYOUT_ID_QUICKALIGN_2VIEW)  # custom two-view layout id defined earlier
+        except Exception as e:
+          logging.error(f"Failed to switch to two-view layout: {e}")
+
+        # Restrict display nodes to just their primary views (remove side views during sync)
         node1 = self.ui.inputSelector1.currentNode()
         node2 = self.ui.inputSelector2.currentNode()
-        if node1.GetNodeTagName() == "MarkupsFiducial" and node2.GetNodeTagName() == "MarkupsFiducial" and self.ui.jointEditCheckBox.checked:
-          self.observerList = logic.startJointMarkupEditing(node1,node2)
-          if self.observerList == []:
-            self.ui.jointEditCheckBox.checked=False
+
+        if node1:
+            self.setDisplayViewNodeIDs(node1.GetDisplayNode(), [self.viewNode1.GetID()])
+        if node2:
+            self.setDisplayViewNodeIDs(node2.GetDisplayNode(), [self.viewNode2.GetID()])
+
+        # Enable landmark selectors now that sync has started
+        self.ui.landmarksSelector1.enabled = True
+        self.ui.landmarksSelector2.enabled = True
+
+        # Filter landmark selectors to exclude Object 1 and Object 2
+        self.filterLandmarkSelectors()
+
+        # Apply landmarks if already selected
+        self.updateLandmarkDisplay()
+
+        self.update3DViews()
+
+        # Update joint editing availability after landmarks are applied
+        self.updateJointEditingAvailability()
+
+        # If joint editing checkbox is enabled and checked, start joint editing
+        if self.ui.jointEditCheckBox.enabled and self.ui.jointEditCheckBox.checked:
+            node1 = self.ui.inputSelector1.currentNode()
+            node2 = self.ui.inputSelector2.currentNode()
+            landmarks1 = self.ui.landmarksSelector1.currentNode()
+            landmarks2 = self.ui.landmarksSelector2.currentNode()
+
+            # Prefer objects if they're fiducials, otherwise use landmarks
+            editNode1 = node1 if self.isFiducialNode(node1) else landmarks1
+            editNode2 = node2 if self.isFiducialNode(node2) else landmarks2
+
+            if editNode1 and editNode2:
+                self.observerList = self.logic.startJointMarkupEditing(editNode1, editNode2)
+                if self.observerList == []:
+                    self.ui.jointEditCheckBox.checked = False
+                    slicer.util.errorDisplay(
+                        "Joint editing was not enabled: the two point lists must have "
+                        "the same number of points.")
 
         #set up for unlink action
         self.ui.unlinkButton.enabled = True
@@ -205,19 +420,39 @@ class QuickAlignWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
         self.cleanUpTransformNodes()
         self.ui.unlinkButton.enabled = False
         self.ui.linkButton.enabled = False
-        # end joint editing if it was initiated
+
         node1 = self.ui.inputSelector1.currentNode()
         node2 = self.ui.inputSelector2.currentNode()
-        if node1.GetNodeTagName() == "MarkupsFiducial" and node2.GetNodeTagName() == "MarkupsFiducial" and self.ui.jointEditCheckBox.checked:
-          self.logic.endJointMarkupEditing(node1, node2, self.observerList)
-        # unlink the views
-        layoutManager = slicer.app.layoutManager()
-        v1 = layoutManager.threeDWidget(0).threeDView().mrmlViewNode()
-        v1.SetLinkedControl(False)
+        landmarks1 = self.ui.landmarksSelector1.currentNode()
+        landmarks2 = self.ui.landmarksSelector2.currentNode()
+
+        # End joint editing if it was initiated
+        if self.ui.jointEditCheckBox.checked and hasattr(self, 'observerList'):
+            # Determine which nodes were being edited
+            editNode1 = node1 if self.isFiducialNode(node1) else landmarks1
+            editNode2 = node2 if self.isFiducialNode(node2) else landmarks2
+
+            if editNode1 and editNode2:
+                self.logic.endJointMarkupEditing(editNode1, editNode2, self.observerList)
+            del self.observerList
+
+        # Disable landmark selectors when not synced, and stop filtering them
+        self.ui.landmarksSelector1.enabled = False
+        self.ui.landmarksSelector2.enabled = False
+        self.clearLandmarkSelectorFilter()
+
+        # Give every display node we touched its original visibility and views back
+        self.restoreDisplayState()
+
+        # unlink all the views
+        for viewNodeAttr in ['viewNode1', 'viewNode2', 'viewNode3', 'viewNode4']:
+            viewNode = getattr(self, viewNodeAttr, None)
+            if viewNode:
+                viewNode.SetLinkedControl(False)
+
         self.update3DViews()
-        self.ui.initializeViewButton.enabled = True
-        markupsTypeNodes = bool(node1.GetNodeTagName() == "MarkupsFiducial" and node2.GetNodeTagName() == "MarkupsFiducial")
-        self.ui.jointEditCheckBox.enabled = markupsTypeNodes
+        self.ui.initializeViewButton.enabled = bool(node1 and node2)
+        self.updateJointEditingAvailability()
 
     def addLayoutButton(self, layoutID, buttonAction, toolTip, imageFileName, layoutDiscription):
         layoutManager = slicer.app.layoutManager()
@@ -236,86 +471,331 @@ class QuickAlignWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
         layoutSwitchAction.connect('triggered()', lambda layoutId = layoutID: slicer.app.layoutManager().setLayout(layoutId))
         layoutSwitchAction.setData(layoutID)
 
-    def centerViews(self, nodeList, viewList):
-      # Center the views
-      layoutManager = slicer.app.layoutManager()
-      camera1 = slicer.modules.cameras.logic().GetViewActiveCameraNode(self.viewNode1)
-      camera2 = slicer.modules.cameras.logic().GetViewActiveCameraNode(self.viewNode2)
-      center1 = np.asarray(camera1.GetFocalPoint())
-      center2 = np.asarray(camera2.GetFocalPoint())
-      translate1=vtk.vtkTransform()
-      translate1.Translate(-center1)
-      translate2=vtk.vtkTransform()
-      translate2.Translate(-center2)
-      self.centerView1Transform = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLLinearTransformNode", "center view 1")
-      self.centerView1Transform.SetMatrixTransformToParent(translate1.GetMatrix())
-      self.centerView2Transform = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLLinearTransformNode", "center view 2")
-      self.centerView2Transform.SetMatrixTransformToParent(translate2.GetMatrix())
+    def centerNodes(self, node1, node2):
+      """Translate both nodes so their geometric (RAS bounds) centers align to origin.
+      Use shared transform per node so rotation stays in place across multiple views."""
+      def nodeCenter(n):
+        bounds = [0,0,0,0,0,0]
+        # Prefer RAS bounds if available
+        try:
+          n.GetRASBounds(bounds)
+        except Exception:
+          # fallback to display node bounds
+          dn = n.GetDisplayNode()
+          if dn:
+            dn.GetBounds(bounds)
+        cx = (bounds[0]+bounds[1])/2.0
+        cy = (bounds[2]+bounds[3])/2.0
+        cz = (bounds[4]+bounds[5])/2.0
+        return np.array([cx,cy,cz])
 
-      for i, currentNode in enumerate(nodeList):
-        if viewList[i] == 'vtkMRMLViewNode1':
-          currentNode.SetAndObserveTransformNodeID(self.centerView1Transform.GetID())
-        if viewList[i] == 'vtkMRMLViewNode2':
-          currentNode.SetAndObserveTransformNodeID(self.centerView2Transform.GetID())
+      c1 = nodeCenter(node1)
+      c2 = nodeCenter(node2)
 
-      #update views
+      t1 = vtk.vtkTransform()
+      t1.Translate(-c1)
+      t2 = vtk.vtkTransform()
+      t2.Translate(-c2)
+
+      self.centerNode1Transform = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLLinearTransformNode", "center node 1")
+      self.centerNode1Transform.SetMatrixTransformToParent(t1.GetMatrix())
+      self.centerNode2Transform = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLLinearTransformNode", "center node 2")
+      self.centerNode2Transform.SetMatrixTransformToParent(t2.GetMatrix())
+
+      node1.SetAndObserveTransformNodeID(self.centerNode1Transform.GetID())
+      node2.SetAndObserveTransformNodeID(self.centerNode2Transform.GetID())
+
+      # Make sure all cameras look at origin now
+      for v in [self.viewNode1, self.viewNode2, self.viewNode3, self.viewNode4]:
+        camNode = slicer.modules.cameras.logic().GetViewActiveCameraNode(v)
+        if camNode:
+          camNode.GetCamera().SetFocalPoint(0,0,0)
       self.update3DViews()
 
     def cleanUpTransformNodes(self):
         # remove alignment transforms from previous runs
-        if hasattr(self, 'centerView1Transform'):
-          slicer.mrmlScene.RemoveNode(self.centerView1Transform)
-        if hasattr(self, 'centerView2Transform'):
-          slicer.mrmlScene.RemoveNode(self.centerView2Transform)
+        if hasattr(self, 'centerNode1Transform'):
+          # First detach the transform before removal
+          if self.centerNode1Transform:
+            self.centerNode1Transform.GetTransformToParent().Identity()
+            self.centerNode1Transform.SetAndObserveTransformNodeID(None)
+          slicer.mrmlScene.RemoveNode(self.centerNode1Transform)
+        if hasattr(self, 'centerNode2Transform'):
+          # First detach the transform before removal
+          if self.centerNode2Transform:
+            self.centerNode2Transform.GetTransformToParent().Identity()
+            self.centerNode2Transform.SetAndObserveTransformNodeID(None)
+          slicer.mrmlScene.RemoveNode(self.centerNode2Transform)
         if hasattr(self, 'alignmentTransform'):
+          # First detach the transform before removal
+          if self.alignmentTransform:
+            self.alignmentTransform.GetTransformToParent().Identity()
+            self.alignmentTransform.SetAndObserveTransformNodeID(None)
           slicer.mrmlScene.RemoveNode(self.alignmentTransform)
         if hasattr(self, 'scalingTransformNode'):
+          # First detach the transform before removal
+          if self.scalingTransformNode:
+            self.scalingTransformNode.GetTransformToParent().Identity()
+            self.scalingTransformNode.SetAndObserveTransformNodeID(None)
           slicer.mrmlScene.RemoveNode(self.scalingTransformNode)
+        self.removeZoomSyncObservers()
+
+    def removeZoomSyncObservers(self):
+        if self._zoomObserverTags:
+            for camNode, tag in self._zoomObserverTags:
+                try:
+                    camNode.RemoveObserver(tag)
+                except Exception:
+                    pass
+        self._zoomObserverTags = []
+        self._zoomSourceToTarget = {}
+        self._zoomSyncActive = False
+
+    def saveDisplayState(self, displayNode):
+        """Remember a display node's visibility and view restriction before we change it.
+
+        The first saved value wins, so repeated calls within one session do not
+        overwrite the user's original state with our own.
+        """
+        if not displayNode:
+            return
+        nodeID = displayNode.GetID()
+        if nodeID in self._savedDisplayState:
+            return
+        self._savedDisplayState[nodeID] = (
+            displayNode.GetVisibility(),
+            list(displayNode.GetViewNodeIDs() or []),
+        )
+
+    def restoreDisplayState(self):
+        """Put every display node this module touched back the way we found it."""
+        for nodeID, (visibility, viewNodeIDs) in self._savedDisplayState.items():
+            displayNode = slicer.mrmlScene.GetNodeByID(nodeID)
+            if not displayNode:
+                continue
+            displayNode.SetViewNodeIDs(viewNodeIDs)
+            displayNode.SetVisibility(visibility)
+        self._savedDisplayState = {}
+
+    def setDisplayViewNodeIDs(self, displayNode, viewNodeIDs):
+        """Restrict a display node to the given views, remembering its prior state."""
+        if not displayNode:
+            return
+        self.saveDisplayState(displayNode)
+        displayNode.SetViewNodeIDs(viewNodeIDs)
+
+    def setDisplayVisibility(self, displayNode, visible):
+        """Set a display node's visibility, remembering its prior state."""
+        if not displayNode:
+            return
+        self.saveDisplayState(displayNode)
+        displayNode.SetVisibility(visible)
+
+    def hideAllObjectsExcept(self, keepNodes):
+        """Hide all models, volumes, and markups except the specified nodes.
+
+        Prior visibility is recorded so that Unlink can restore it.
+        """
+        keepNodeIDs = {n.GetID() for n in keepNodes if n}
+
+        # Hide all models
+        models = slicer.util.getNodesByClass('vtkMRMLModelNode')
+        for model in models:
+            if model.GetID() not in keepNodeIDs:
+                self.setDisplayVisibility(model.GetDisplayNode(), False)
+
+        # Hide all volumes (scalar and volume rendering)
+        volumes = slicer.util.getNodesByClass('vtkMRMLScalarVolumeNode')
+        for vol in volumes:
+            if vol.GetID() not in keepNodeIDs:
+                for i in range(vol.GetNumberOfDisplayNodes()):
+                    self.setDisplayVisibility(vol.GetNthDisplayNode(i), False)
+
+        # Hide all markups
+        markups = slicer.util.getNodesByClass('vtkMRMLMarkupsNode')
+        for markup in markups:
+            if markup.GetID() not in keepNodeIDs:
+                self.setDisplayVisibility(markup.GetDisplayNode(), False)
 
     def onInitializeViewButton(self):
         self.cleanUpTransformNodes()
-        customLayoutId1=701
+        # Undo any display changes left over from an earlier initialization, so
+        # that re-initializing does not bake our own state in as the "original".
+        self.restoreDisplayState()
+
+        # Get selected objects
+        node1 = self.ui.inputSelector1.currentNode()
+        node2 = self.ui.inputSelector2.currentNode()
+        if not (node1 and node2):
+            slicer.util.errorDisplay("Please select both Object 1 and Object 2.")
+            return
+
+        customLayoutId1=LAYOUT_ID_QUICKALIGN_4VIEW  # Use the 2x2 QuickAlignLayout
         layoutManager = slicer.app.layoutManager()
         layoutManager.setLayout(customLayoutId1)
 
-        #set up 2 unlinked 3D views
+        #set up 4 3D views
         self.viewNode1 = slicer.mrmlScene.GetFirstNodeByName("View1") #name = "View"+ singletonTag
         self.viewNode2 = slicer.mrmlScene.GetFirstNodeByName("View2")
-        self.viewNode1.SetAxisLabelsVisible(False)
-        self.viewNode2.SetAxisLabelsVisible(False)
-        self.viewNode1.SetBoxVisible(False)
-        self.viewNode2.SetBoxVisible(False)
+        self.viewNode3 = slicer.mrmlScene.GetFirstNodeByName("View3")
+        self.viewNode4 = slicer.mrmlScene.GetFirstNodeByName("View4")
 
-        #set up selected nodes in views
-        node1 = self.ui.inputSelector1.currentNode()
-        node2 = self.ui.inputSelector2.currentNode()
-        # Set up list of nodes and assigned views. Can be expanded later to multiple nodes, views
-        nodeList=[node1, node2]
-        viewList=[self.viewNode1.GetID(), self.viewNode2.GetID()]
+        if not self.hasFourViewNodes():
+            slicer.util.errorDisplay(
+                "Could not create the four 3D views required by QuickAlign. "
+                "Please switch to the 'QuickAlignLayout' layout and try again.")
+            return
+
+        # Hide all other objects in the scene. Done only once the views are known
+        # to exist, so a failure above leaves the scene untouched.
+        self.hideAllObjectsExcept([node1, node2])
+
+        # Configure all views
+        for viewNode in [self.viewNode1, self.viewNode2, self.viewNode3, self.viewNode4]:
+            viewNode.SetAxisLabelsVisible(False)
+            viewNode.SetBoxVisible(False)
+
+        # Desired view assignments:
+        #   node1 -> View1 & View3
+        #   node2 -> View2 & View4
+        node1Views = [self.viewNode1.GetID(), self.viewNode3.GetID()]
+        node2Views = [self.viewNode2.GetID(), self.viewNode4.GetID()]
         volRenLogic = slicer.modules.volumerendering.logic()
 
-        for i, currentNode in enumerate(nodeList):
-          if currentNode.GetNodeTagName() == "Volume":
-            if currentNode.GetNumberOfDisplayNodes() > 1:
-              displayNode = currentNode.GetNthDisplayNode(1)
-            else:
-              displayNode = volRenLogic.CreateDefaultVolumeRenderingNodes(currentNode)
-              displayNode.GetVolumePropertyNode().Copy(volRenLogic.GetPresetByName("US-Fetal"))
-          else:
-            displayNode=currentNode.GetDisplayNode()
-          displayNode.SetVisibility(True)
-          displayNode.SetViewNodeIDs([viewList[i]])
+        def prepareVolumeRenderingDisplay(n):
+          # Ensure a volume rendering display node exists and return it
+          vrDisplayNode = None
+          for i in range(n.GetNumberOfDisplayNodes()):
+            dn = n.GetNthDisplayNode(i)
+            if dn.IsA("vtkMRMLVolumeRenderingDisplayNode"):
+              vrDisplayNode = dn
+          if vrDisplayNode is None:
+            vrDisplayNode = volRenLogic.CreateDefaultVolumeRenderingNodes(n)
+            # Use a neutral preset if available
+            preset = volRenLogic.GetPresetByName("MR-Default") or volRenLogic.GetPresetByName("CT-AAA") or volRenLogic.GetPresetByName("US-Fetal")
+            if preset:
+              vrDisplayNode.GetVolumePropertyNode().Copy(preset)
+          return vrDisplayNode
 
+        def assignViews(n, desiredViews):
+          if n is None:
+            return
+          if n.GetNodeTagName() == "Volume":
+            vrDisplayNode = prepareVolumeRenderingDisplay(n)
+            # Hide scalar volume display nodes (to avoid duplicate rendering) and restrict VR display
+            for i in range(n.GetNumberOfDisplayNodes()):
+              dn = n.GetNthDisplayNode(i)
+              if dn == vrDisplayNode:
+                self.setDisplayViewNodeIDs(dn, desiredViews)
+                self.setDisplayVisibility(dn, True)
+              else:
+                # Hide other display nodes (slice or scalar) in 3D views; they will still be available in slice viewers if needed
+                self.setDisplayVisibility(dn, False)
+          else:
+            dn = n.GetDisplayNode()
+            self.setDisplayViewNodeIDs(dn, desiredViews)
+            self.setDisplayVisibility(dn, True)
+
+        assignViews(node1, node1Views)
+        assignViews(node2, node2Views)
+
+        # Unlink all views initially
         self.viewNode1.SetLinkedControl(False)
         self.viewNode2.SetLinkedControl(False)
-        self.ui.linkButton.enabled = True
-        self.ui.unlinkButton.enabled = False
+        self.viewNode3.SetLinkedControl(False)
+        self.viewNode4.SetLinkedControl(False)
 
         #update views
         self.update3DViews()
 
+        # Set camera orientations
+        # View 1: Superior view (looking down from top)
+        # View 3: Side/Lateral view (90 degree rotation)
+        # View 2: Superior view
+        # View 4: Side/Lateral view
+        self.setCameraOrientation(self.viewNode1, viewUp=[0, 1, 0], position=[0, 0, 1])
+        self.setCameraOrientation(self.viewNode3, viewUp=[0, 0, 1], position=[1, 0, 0])
+        self.setCameraOrientation(self.viewNode2, viewUp=[0, 1, 0], position=[0, 0, 1])
+        self.setCameraOrientation(self.viewNode4, viewUp=[0, 0, 1], position=[1, 0, 0])
+
+        # Setup zoom synchronization (1 <-> 3) and (2 <-> 4) for initialization
+        self.setupZoomSyncPairs()
+
+        self.ui.linkButton.enabled = True
+        self.ui.unlinkButton.enabled = False
+
         #translate all nodes to origin
-        self.centerViews(nodeList, viewList)
+        self.centerNodes(node1, node2)
+
+    def setCameraOrientation(self, viewNode, viewUp, position):
+        """Set camera orientation for a specific view"""
+        camera = slicer.modules.cameras.logic().GetViewActiveCameraNode(viewNode)
+        if camera:
+            # Get the camera
+            cam = camera.GetCamera()
+            # Reset the camera to default
+            cam.SetPosition(position[0] * 500, position[1] * 500, position[2] * 500)
+            cam.SetFocalPoint(0, 0, 0)
+            cam.SetViewUp(viewUp[0], viewUp[1], viewUp[2])
+            cam.OrthogonalizeViewUp()
+            # Reset the clipping range
+            layoutManager = slicer.app.layoutManager()
+            threeDWidget = layoutManager.threeDWidget(viewNode)
+            if threeDWidget:
+                threeDView = threeDWidget.threeDView()
+                threeDView.resetFocalPoint()
+
+    # ---- Zoom synchronization helpers ----
+    def setupZoomSyncPairs(self):
+      self.removeZoomSyncObservers()
+      pairs = [
+        (self.viewNode1, self.viewNode3),  # object 1 superior & side
+        (self.viewNode2, self.viewNode4),  # object 2 superior & side
+      ]
+      for sourceViewNode, targetViewNode in pairs:
+        sourceCamNode = slicer.modules.cameras.logic().GetViewActiveCameraNode(sourceViewNode)
+        targetCamNode = slicer.modules.cameras.logic().GetViewActiveCameraNode(targetViewNode)
+        if not sourceCamNode or not targetCamNode:
+          continue
+        # Initial sync of zoom level
+        self.copyZoom(sourceCamNode, targetCamNode)
+        # Record mapping and add observer
+        self._zoomSourceToTarget[sourceCamNode.GetID()] = targetCamNode
+        tag = sourceCamNode.AddObserver(vtk.vtkCommand.ModifiedEvent, self.onZoomSourceModified)
+        self._zoomObserverTags.append((sourceCamNode, tag))
+
+    def copyZoom(self, sourceCamNode, targetCamNode):
+      srcCam = sourceCamNode.GetCamera()
+      tgtCam = targetCamNode.GetCamera()
+      if srcCam.GetParallelProjection():
+        tgtCam.SetParallelScale(srcCam.GetParallelScale())
+      else:
+        # Perspective: match distance while keeping target orientation
+        focal = np.array(tgtCam.GetFocalPoint())
+        pos = np.array(tgtCam.GetPosition())
+        direction = pos - focal
+        norm = np.linalg.norm(direction)
+        newDist = srcCam.GetDistance()
+        if norm > 1e-6:
+          newPos = focal + direction / norm * newDist
+          tgtCam.SetPosition(*newPos)
+        else:
+          # Degenerate case: camera position equals focal point
+          logging.warning("QuickAlign: Camera position equals focal point, skipping zoom sync")
+      targetCamNode.Modified()
+
+    def onZoomSourceModified(self, caller, event):
+      if self._zoomSyncActive:
+        return
+      camNode = caller  # vtkMRMLCameraNode
+      target = self._zoomSourceToTarget.get(camNode.GetID())
+      if not target:
+        return
+      self._zoomSyncActive = True
+      try:
+        self.copyZoom(camNode, target)
+      finally:
+        self._zoomSyncActive = False
 
 #
 # QuickAlignLogic
@@ -336,7 +816,9 @@ class QuickAlignLogic(ScriptedLoadableModuleLogic):
         Called when the logic class is instantiated. Can be used for initializing member variables.
         """
         ScriptedLoadableModuleLogic.__init__(self)
-    @vtk.calldata_type(vtk.VTK_INT)
+        self.node1 = None
+        self.node2 = None
+        self.updatingNodesActive = False
 
     def getCameraAlignmentTransform(self, camera1, camera2):
       #get transform matrices from cameras
@@ -367,12 +849,13 @@ class QuickAlignLogic(ScriptedLoadableModuleLogic):
         self.updatingNodesActive = True
         for i in range(self.node2.GetNumberOfControlPoints()):
           self.node1.SetNthControlPointSelected(i,self.node2.GetNthControlPointSelected(i))
-          self.updatingNodesActive = False
+        self.updatingNodesActive = False
 
     def startJointMarkupEditing(self, inputNode1, inputNode2):
         logging.info('Enabling joint editing of point list nodes')
+        # The logic class stays GUI-free; the widget reports the failure to the user.
         if inputNode1.GetNumberOfControlPoints() != inputNode2.GetNumberOfControlPoints():
-          print("Error: point lists must have same number of points to enable joint editing.")
+          logging.error("QuickAlign: point lists must have the same number of points to enable joint editing.")
           return []
         self.node1 = inputNode1
         self.node2 = inputNode2
@@ -386,12 +869,15 @@ class QuickAlignLogic(ScriptedLoadableModuleLogic):
 
     def endJointMarkupEditing(self, inputNode1, inputNode2, observerTags):
         logging.info('Ending joint editing of point lists')
-        try:
-          inputNode1.RemoveObserver(observerTags[0])
-        except:
-          print(f"No tag found for {inputNode1.GetName()}")
-        try:
-          inputNode2.RemoveObserver(observerTags[1])
-        except:
-          print(f"No tag found for {inputNode2.GetName()}")
+        for inputNode, observerTag in zip([inputNode1, inputNode2], observerTags):
+          try:
+            inputNode.RemoveObserver(observerTag)
+          except Exception:
+            logging.warning(f"QuickAlign: no observer tag found for {inputNode.GetName()}")
+          # Release the lock that startJointMarkupEditing put on the point list,
+          # otherwise the user cannot add or remove points after unlinking.
+          inputNode.SetFixedNumberOfControlPoints(False)
+        self.node1 = None
+        self.node2 = None
+        self.updatingNodesActive = False
 

--- a/QuickAlign/Resources/UI/QuickAlign.ui
+++ b/QuickAlign/Resources/UI/QuickAlign.ui
@@ -111,7 +111,87 @@
       <string>Synchronize View</string>
      </property>
      <layout class="QFormLayout" name="formLayout_3">
-      <item row="0" column="0" colspan="2">
+      <item row="0" column="0">
+       <widget class="QLabel" name="landmarksLabel1">
+        <property name="text">
+         <string>Landmarks 1:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="qMRMLNodeComboBox" name="landmarksSelector1">
+        <property name="enabled">
+         <bool>false</bool>
+        </property>
+        <property name="toolTip">
+         <string>Optional: Select landmarks/fiducials for Object 1</string>
+        </property>
+        <property name="nodeTypes">
+         <stringlist notr="true">
+          <string>vtkMRMLMarkupsFiducialNode</string>
+          <string>vtkMRMLMarkupsLineNode</string>
+          <string>vtkMRMLMarkupsCurveNode</string>
+          <string>vtkMRMLMarkupsPlaneNode</string>
+         </stringlist>
+        </property>
+        <property name="showChildNodeTypes">
+         <bool>false</bool>
+        </property>
+        <property name="noneEnabled">
+         <bool>true</bool>
+        </property>
+        <property name="addEnabled">
+         <bool>false</bool>
+        </property>
+        <property name="removeEnabled">
+         <bool>false</bool>
+        </property>
+        <property name="selectNodeUponCreation">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="0">
+       <widget class="QLabel" name="landmarksLabel2">
+        <property name="text">
+         <string>Landmarks 2:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <widget class="qMRMLNodeComboBox" name="landmarksSelector2">
+        <property name="enabled">
+         <bool>false</bool>
+        </property>
+        <property name="toolTip">
+         <string>Optional: Select landmarks/fiducials for Object 2</string>
+        </property>
+        <property name="nodeTypes">
+         <stringlist notr="true">
+          <string>vtkMRMLMarkupsFiducialNode</string>
+          <string>vtkMRMLMarkupsLineNode</string>
+          <string>vtkMRMLMarkupsCurveNode</string>
+          <string>vtkMRMLMarkupsPlaneNode</string>
+         </stringlist>
+        </property>
+        <property name="showChildNodeTypes">
+         <bool>false</bool>
+        </property>
+        <property name="noneEnabled">
+         <bool>true</bool>
+        </property>
+        <property name="addEnabled">
+         <bool>false</bool>
+        </property>
+        <property name="removeEnabled">
+         <bool>false</bool>
+        </property>
+        <property name="selectNodeUponCreation">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="0" colspan="2">
        <widget class="QCheckBox" name="jointEditCheckBox">
         <property name="enabled">
          <bool>false</bool>
@@ -124,7 +204,7 @@
         </property>
        </widget>
       </item>
-      <item row="1" column="0" colspan="2">
+      <item row="3" column="0" colspan="2">
        <widget class="QPushButton" name="linkButton">
         <property name="enabled">
          <bool>false</bool>
@@ -137,7 +217,7 @@
         </property>
        </widget>
       </item>
-      <item row="2" column="0" colspan="2">
+      <item row="4" column="0" colspan="2">
        <widget class="QPushButton" name="unlinkButton">
         <property name="enabled">
          <bool>false</bool>


### PR DESCRIPTION
## What this is

The QuickAlign 4-view work merged to `master` in #416 (Nov 2025) never reached `geomorphTab` — the branch forked from `master` at `8d48ccb` on 2025-08-01, months before #416 landed, and has never been re-synced. This ports it, with fixes for defects found reviewing the master version.

## The feature

A 2×2 `QuickAlignLayout` (layout ID 702) alongside the existing 2-view layout (701). Columns are specimens, rows are orientations:

|        | Object 1 | Object 2 |
|--------|----------|----------|
| **Superior** | View 1 | View 2 |
| **Lateral**  | View 3 | View 4 |

Zoom is synchronized within each specimen's pair (1↔3, 2↔4). **Link** still computes the camera alignment between the two superior views and drops back to the 2-view layout. Also adds optional landmark selectors, so joint point-list editing works on landmark sets rather than only when the aligned objects are themselves point lists.

## Fixes on top of the master version

**`onUnlinkButton` raised `NameError`.** #416 moved the `node1`/`node2` lookups inside the joint-editing branch but left the trailing `markupsTypeNodes` line using them unconditionally. Any Unlink without active joint editing threw, aborting partway and leaving the joint-editing checkbox stuck disabled. Lookups hoisted.

**Display changes were never undone.** `hideAllObjectsExcept()` hid every other model, volume, and markup in the scene, and the selected nodes' display nodes were pinned to `View1`/`View2` — none of it restored. After using the module, object 2 and its landmarks were invisible in any standard layout (which has no `View2`) and the rest of the scene stayed hidden; the user had to repair visibility by hand in the Data module. Prior visibility and view assignments are now recorded on first touch and restored on Unlink, and before re-initializing.

**Landmark filtering did nothing.** `filterLandmarkSelectors()` built a negative-lookahead regex and assigned it to `qMRMLNodeComboBox.baseName` — which is the default name for nodes *created* from the combo box, not a filter — inside a bare `except`, so the no-op was silent. Replaced with `sortFilterProxyModel().setHiddenNodeIDs()`, cleared again on Unlink.

**Joint editing used two different logic instances.** Link called `QuickAlignLogic().startJointMarkupEditing(...)` on a throwaway instance that stashed `node1`/`node2`/`updatingNodesActive` on itself, while Unlink ended it through `self.logic`. Both now use `self.logic`.

**Zoom-sync observers leaked.** They are added directly on the camera nodes, so `VTKObservationMixin.removeObservers()` never saw them. `cleanup()` now calls `removeZoomSyncObservers()`.

**`updateSelectPoints2()` cleared its re-entrancy guard inside the control-point loop** instead of after it (compare `updateSelectPoints1`), so every point after the first re-entered the paired callback. Pre-existing on `geomorphTab`; fixed here.

**`endJointMarkupEditing()` left `SetFixedNumberOfControlPoints(True)`** on both point lists, so points could not be added or removed after unlinking. Pre-existing; fixed here.

**`onInitializeViewButton()` dereferenced `View3`/`View4` without checking** that the layout produced them, and hid the whole scene *before* that check — so a failure left the scene wrecked. Now guarded, and the scene is only touched once the views are known to exist.

**Cleanups:** dropped a stray `@vtk.calldata_type(vtk.VTK_INT)` decorator sitting on `getCameraAlignmentTransform` (not a VTK callback, pre-existing); `print()` error paths replaced with `errorDisplay` in the widget and `logging` in the logic class, keeping the logic GUI-free; removed the unused `math` import and the stray `"` characters in the 2-view layout XML.

The module category (`SlicerMorph.Utilities`) and the funding acknowledgement stay as they are on `geomorphTab` — `master` predates both changes, so taking its file wholesale would have reverted them.

## Testing

`pyupgrade --py39-plus`, `codespell`, trailing-whitespace, and `check-ast` all pass locally. Needs interactive verification in Slicer: initialize with two models and with two volumes, confirm the 4-view assignment and per-pair zoom sync, Link → 2-view alignment, then Unlink and confirm the scene's visibility and layout come back intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)